### PR TITLE
Remove deprecation warning of Home Assistant 2025.10.0 for Homematic(IP) local

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,7 @@
 # Version 1.87.1 (2025-09-25)
 
+# This release requires HA 2025.10.0 or later.
+
 ## What's Changed
 
 - Remove deprecation warning (The deprecated argument hass was passed to verify_domain_control) of Home Assistant 2025.10.0 for Homematic(IP local)

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,9 @@
+# Version 1.87.1 (2025-09-25)
+
+## What's Changed
+
+- Remove deprecation warning (The deprecated argument hass was passed to verify_domain_control) of Home Assistant 2025.10.0 for Homematic(IP local)
+
 # Version 1.87.0 (2025-09-24)
 
 ## What's Changed

--- a/custom_components/homematicip_local/const.py
+++ b/custom_components/homematicip_local/const.py
@@ -10,7 +10,7 @@ from aiohomematic.const import CATEGORIES
 from homeassistant.const import Platform
 
 DOMAIN: Final = "homematicip_local"
-HMIP_LOCAL_MIN_HA_VERSION: Final = "2025.8.0"
+HMIP_LOCAL_MIN_HA_VERSION: Final = "2025.10.0b0"
 ENABLE_EXPERIMENTAL_FEATURES: Final = False
 
 DEFAULT_ENABLE_DEVICE_FIRMWARE_CHECK: Final = True

--- a/custom_components/homematicip_local/manifest.json
+++ b/custom_components/homematicip_local/manifest.json
@@ -17,6 +17,6 @@
       "manufacturerURL": "http://www.homematic.com"
     }
   ],
-  "version": "1.87.0",
+  "version": "1.87.1",
   "zeroconf": []
 }

--- a/custom_components/homematicip_local/services.py
+++ b/custom_components/homematicip_local/services.py
@@ -223,7 +223,7 @@ SCHEMA_UPDATE_DEVICE_FIRMWARE_DATA = vol.Schema(
 async def async_setup_services(hass: HomeAssistant) -> None:
     """Create the aiohomematic services."""
 
-    @verify_domain_control(hass, DOMAIN)
+    @verify_domain_control(DOMAIN)
     async def async_call_hmip_local_service(service: ServiceCall) -> ServiceResponse:
         """Call correct Homematic(IP) Local service."""
         service_name = service.service

--- a/hacs.json
+++ b/hacs.json
@@ -1,6 +1,6 @@
 {
   "name": "Homematic(IP) Local",
   "hide_default_branch": false,
-  "homeassistant": "2025.8.0",
+  "homeassistant": "2025.10.0b0",
   "hacs": "2.0.5"
 }

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -9,4 +9,4 @@ pur==7.3.3
 pydevccu==0.1.17
 pylint==3.3.8
 pylint_strict_informational==0.1
-pytest-homeassistant-custom-component==0.13.281
+pytest-homeassistant-custom-component==0.13.282


### PR DESCRIPTION
Remove deprecation warning (The deprecated argument hass was passed to verify_domain_control) of Home Assistant 2025.10.0 for Homematic(IP) local