### PR TITLE
feat(alarm): own device for the alarm system, and a motion reset — 2.9.2

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ This document provides comprehensive guidance for AI assistants working with the
 
 **Project Name:** Homematic(IP) Local for OpenCCU
 **Type:** Home Assistant Custom Integration
-**Version:** 2.9.1
+**Version:** 2.9.2
 **Primary Language:** Python 3.14+
 **Domain:** `homematicip_local`
 
@@ -118,7 +118,7 @@ homematicip_local/
 
 ### Runtime Dependencies
 
-- **aiohomematic** (v2026.8.1) - Core async library for Homematic device communication
+- **aiohomematic** (v2026.8.2) - Core async library for Homematic device communication
 - **aiohomematic-config** (v2026.8.0) - Device configuration metadata
 - **Home Assistant Core** - Minimum version: 2026.7.0+
 - **Python 3.14+** (target version for development)
@@ -1123,10 +1123,10 @@ make hass
 
 ### Version Information
 
-- **Current Version:** 2.9.1
+- **Current Version:** 2.9.2
 - **Minimum HA Version:** 2026.7.0+
 - **Python Target:** 3.14+ (CI tests on 3.14)
-- **aiohomematic Version:** 2026.8.1
+- **aiohomematic Version:** 2026.8.2
 
 ### External Resources
 
@@ -1139,5 +1139,5 @@ make hass
 
 ---
 
-**Last Updated**: 2026-08-07
-**Version**: 2.9.1
+**Last Updated**: 2026-08-12
+**Version**: 2.9.2

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,22 @@
+# Version [2.9.2](https://github.com/SukramJ/homematicip_local/compare/2.9.1...2.9.2) (2026-08-12)
+
+## What's Changed
+
+### Development
+
+- The openccu-loom alarm system (Beta) gets a device of its own, `OpenCCU-Loom Alarm`, and every alarm entity moves onto it. Alarm zones are daemon-level and may hold sensors of several CCUs, so listing the panels under one central stated a belonging that does not exist — and buried them among dozens of system variables, programs and diagnostic values. The device identifier is the daemon's own, so an installation that also runs the daemon's MQTT bridge sees one alarm device rather than two describing the same zones ([#89](https://github.com/SukramJ/openccu-loom-client/issues/89))
+- Latched motion detectors can be cleared from Home Assistant: a reset button per alarm zone plus one for the aggregate, and a diagnostic counter beside each. A motion detector holds its `MOTION` flag until the device's own blocking time expires, and reads as open until then — which blocks an arm or forces an auto-bypass with nothing to do but wait. The button ends the wait; the counter answers why a zone will not arm. Presence detectors are covered too, door contacts fall out by construction. Requires an openccu-loom daemon ≥ 0.58.1 — 0.58.0 shipped the routes but they were inert on real hardware ([#88](https://github.com/SukramJ/openccu-loom-client/issues/88))
+- The reset button is deliberately a plain control, not a config entity: the daemon shipped it as `config` first and nobody found it, because Home Assistant files such entities into a collapsed section of the device page and keeps them out of dashboards. Only the counter is diagnostic
+- The user-facing details of the loom backend stay out of scope for this changelog until it leaves Beta
+
+### Dependencies
+
+#### Bump openccu-loom-client to `2026.8.11` (pins `openccu-loom-types==0.3.14`)
+
+- Adds the alarm motion-reset surface the two entities above are built on: the REST verbs, `AlarmPanel.reset_motion()`, and the per-zone latched-detector count
+- The count is refreshed by re-reading rather than pushed — the daemon broadcasts no latch event — and the client schedules that read off the alarm events that can plausibly move a latch, coalescing bursts into one call
+- **This raises the daemon floor: the client refuses to connect to an openccu-loom below 0.58.3.** Installations on an older daemon should stay on 2.9.1 until the daemon is updated
+
 # Version [2.9.1](https://github.com/SukramJ/homematicip_local/compare/2.9.0...2.9.1) (2026-08-10)
 
 ## What's Changed

--- a/custom_components/homematicip_local/alarm_control_panel.py
+++ b/custom_components/homematicip_local/alarm_control_panel.py
@@ -35,7 +35,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from . import HomematicConfigEntry
 from .backend_types import LOOM_DP_ALARM_CONTROL_PANEL
 from .control_unit import ControlUnit, signal_new_data_point
-from .generic_entity import AioHomematicGenericHubEntity
+from .generic_entity import AioHomematicAlarmEntity
 from .support import handle_homematic_errors
 
 if TYPE_CHECKING:
@@ -97,7 +97,7 @@ async def async_setup_entry(
     )
 
 
-class AioHomematicAlarmControlPanel(AioHomematicGenericHubEntity, AlarmControlPanelEntity):
+class AioHomematicAlarmControlPanel(AioHomematicAlarmEntity, AlarmControlPanelEntity):
     """Representation of the HomematicIP alarm control panel entity (openccu-loom)."""
 
     def __init__(

--- a/custom_components/homematicip_local/button.py
+++ b/custom_components/homematicip_local/button.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
-from typing import override
+from typing import TYPE_CHECKING, Any, cast, override
 
 from aiohomematic.const import DataPointCategory, DataPointType
 from aiohomematic.exceptions import BaseHomematicException
@@ -15,11 +15,27 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.typing import UndefinedType
 
 from . import HomematicConfigEntry
+from .backend_types import LOOM_DP_ALARM_CONTROL_PANEL
 from .const import DOMAIN
 from .control_unit import ControlUnit, signal_new_data_point
-from .generic_entity import ATTR_DESCRIPTION, ATTR_NAME, AioHomematicGenericEntity, AioHomematicGenericHubEntity
+from .generic_entity import (
+    ATTR_DESCRIPTION,
+    ATTR_NAME,
+    AioHomematicAlarmEntity,
+    AioHomematicGenericEntity,
+    AioHomematicGenericHubEntity,
+)
+from .support import handle_homematic_errors
+
+if TYPE_CHECKING:
+    # Typing-only: the loom twin is absent on a CCU-only install, where the
+    # dispatch tuple is empty and this entity is never constructed.
+    from openccu_loom_client.compat.aiohomematic.model.alarm_panel import LoomDpAlarmControlPanel
+
+    from aiohomematic.interfaces.model import GenericHubDataPointProtocol
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -56,11 +72,34 @@ async def async_setup_entry(
         ]:
             async_add_entities(entities)
 
+    @callback
+    def async_add_alarm_motion_reset_button(data_points: tuple[Any, ...]) -> None:
+        """Add a motion-reset button per alarm panel (openccu-loom only)."""
+        _LOGGER.debug("ASYNC_ADD_ALARM_MOTION_RESET_BUTTON: Adding %i data points", len(data_points))
+
+        if entities := [
+            AioHomematicAlarmMotionResetButton(control_unit=control_unit, data_point=data_point)
+            for data_point in data_points
+            # Loom-only surface: the tuple is empty on a CCU-only install.
+            if isinstance(data_point, LOOM_DP_ALARM_CONTROL_PANEL)
+        ]:
+            async_add_entities(entities)
+
     entry.async_on_unload(
         func=async_dispatcher_connect(
             hass=hass,
             signal=signal_new_data_point(entry_id=entry.entry_id, platform=DataPointCategory.BUTTON),
             target=async_add_button,
+        )
+    )
+
+    # The reset button rides the alarm panel data point, so it spawns off the
+    # same announce a panel does — including a zone created at runtime.
+    entry.async_on_unload(
+        func=async_dispatcher_connect(
+            hass=hass,
+            signal=signal_new_data_point(entry_id=entry.entry_id, platform=DataPointCategory.ALARM_CONTROL_PANEL),
+            target=async_add_alarm_motion_reset_button,
         )
     )
 
@@ -79,6 +118,10 @@ async def async_setup_entry(
     )
 
     async_add_program_button(data_points=control_unit.get_new_hub_data_points(data_point_type=ProgramDpButton))
+
+    async_add_alarm_motion_reset_button(
+        data_points=control_unit.get_new_data_points(data_point_type=DataPointType.ALARM_CONTROL_PANEL)
+    )
 
     # Add hub-level backup button
     async_add_entities([HmipLocalCreateBackupButton(control_unit=control_unit)])
@@ -116,6 +159,84 @@ class AioHomematicProgramButton(AioHomematicGenericHubEntity, ButtonEntity):
     async def async_press(self) -> None:
         """Execute a button press."""
         await self._data_point.press()
+
+
+class AioHomematicAlarmMotionResetButton(AioHomematicAlarmEntity, ButtonEntity):
+    """
+    Clears a zone's latched motion/presence detectors (openccu-loom).
+
+    A detector holds its ``MOTION`` flag until the device's own blocking
+    time expires, and reads as open until then — which blocks an arm or
+    forces an auto-bypass with nothing to do but wait. This is the
+    control that ends the wait; the daemon offers the same one in its own
+    UI and over MQTT.
+
+    Deliberately **not** ``EntityCategory.CONFIG``. openccu-loom shipped
+    it that way first and nobody found it: Home Assistant files config
+    entities into a collapsed section of the device page and keeps them
+    out of dashboards. This is an operator control, so it stays a plain
+    one; only the counter beside it is diagnostic.
+
+    Rides the panel data point, so it inherits the panel's availability,
+    its refresh subscription and its removal when a zone disappears.
+    """
+
+    _attr_translation_key = "alarm_reset_motion"
+
+    def __init__(
+        self,
+        control_unit: ControlUnit,
+        data_point: LoomDpAlarmControlPanel,
+    ) -> None:
+        """Initialize the motion-reset button."""
+        super().__init__(
+            control_unit=control_unit,
+            # Same structural-satisfaction cast the panel platform makes:
+            # only the enum homes differ nominally.
+            data_point=cast("GenericHubDataPointProtocol", data_point),
+        )
+        # The base keys the unique id on the data point alone, which the
+        # panel entity already claims — this rides the same data point.
+        self._attr_unique_id = f"{DOMAIN}_{data_point.unique_id}_reset_motion"
+        # One device holds every zone, so the zone has to be in the entity
+        # name or the buttons are indistinguishable. Mirrors the daemon's
+        # own MQTT naming ("<zone> — Reset motion").
+        self._attr_translation_placeholders = {"zone": data_point.name}
+
+    @property
+    def _panel(self) -> LoomDpAlarmControlPanel:
+        """Return the data point as its concrete loom type."""
+        return cast("LoomDpAlarmControlPanel", self._data_point)
+
+    @property
+    @override
+    def name(self) -> str | UndefinedType | None:
+        """
+        Return Home Assistant's own composed name.
+
+        The hub base prefers the data point's daemon-resolved name, which
+        belongs to the *panel* this entity rides — taking it would leave
+        the button and the panel sharing one name. This entity is named by
+        the integration, so the normal translation lookup applies.
+        """
+        return super(AioHomematicGenericHubEntity, self).name
+
+    @handle_homematic_errors
+    @override
+    async def async_press(self) -> None:
+        """Clear this zone's latched detectors (master: every zone)."""
+        result = await self._panel.reset_motion()
+        if result.failed:
+            # Not an error: the verb ran and the daemon reports the partial
+            # outcome in the body. Raising would claim nothing happened.
+            _LOGGER.warning(
+                "Motion reset for %s: %i detector(s) cleared, %i did not answer",
+                self._panel.name,
+                result.reset,
+                result.failed,
+            )
+        else:
+            _LOGGER.debug("Motion reset for %s: %i detector(s) cleared", self._panel.name, result.reset)
 
 
 class HmipLocalCreateBackupButton(ButtonEntity):

--- a/custom_components/homematicip_local/const.py
+++ b/custom_components/homematicip_local/const.py
@@ -10,6 +10,20 @@ from homeassistant.const import Platform
 
 DOMAIN: Final = "homematicip_local"
 HMIP_LOCAL_MIN_HA_VERSION: Final = "2026.7.0"
+
+# The openccu-loom alarm system gets a device registry object of its own
+# instead of hanging off a CCU. Alarm zones are daemon-level and may hold
+# sensors of several CCUs, so attributing them to one central states a
+# belonging that does not exist — which is also why the daemon's MQTT plane
+# omits the `<central>` segment from its alarm topics. The identifier is the
+# daemon's own (`alarm_discovery.go`, `alarmDeviceBlock`), so an installation
+# running both bridges sees one alarm device rather than two; it also matches
+# the scope of the panel unique_ids, which the daemon computes daemon-wide
+# rather than per central.
+ALARM_DEVICE_IDENTIFIER: Final = "openccu-loom_alarm"
+ALARM_DEVICE_MANUFACTURER: Final = "OpenCCU-Loom"
+ALARM_DEVICE_NAME: Final = "OpenCCU-Loom Alarm"
+
 ENABLE_EXPERIMENTAL_FEATURES: Final = False
 CLIMATE_SCHEDULE_API_VERSION: Final = "v2.0"
 SCHEDULE_API_VERSION: Final = "v1.0"

--- a/custom_components/homematicip_local/generic_entity.py
+++ b/custom_components/homematicip_local/generic_entity.py
@@ -27,7 +27,14 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.typing import UndefinedType
 
-from .const import DOMAIN, ENTITY_TRANSLATION_KEYS, HmEntityState
+from .const import (
+    ALARM_DEVICE_IDENTIFIER,
+    ALARM_DEVICE_MANUFACTURER,
+    ALARM_DEVICE_NAME,
+    DOMAIN,
+    ENTITY_TRANSLATION_KEYS,
+    HmEntityState,
+)
 from .control_unit import ControlUnit
 from .entity_helpers import get_entity_description
 from .support import (
@@ -619,6 +626,28 @@ class AioHomematicGenericHubEntity(Entity):
         return DeviceInfo(
             identifiers={(DOMAIN, self._data_point.channel.device.identifier)},
             suggested_area=self._data_point.channel.device.room,
+        )
+
+
+class AioHomematicAlarmEntity(AioHomematicGenericHubEntity):
+    """
+    Base for every openccu-loom alarm surface (panel, reset button, counter).
+
+    Exists for one reason: the alarm system is not part of any CCU. Its
+    zones live in the daemon and may hold sensors of several centrals, so
+    the hub default of attaching to the central's device states a
+    belonging that does not exist — and buries the panels among dozens of
+    sysvars and diagnostics while it is at it. Everything alarm-related
+    goes on one device of its own instead, matching the block the daemon
+    publishes over MQTT.
+    """
+
+    def _get_device_info(self) -> DeviceInfo | None:
+        """Return the shared alarm device instead of the central's."""
+        return DeviceInfo(
+            identifiers={(DOMAIN, ALARM_DEVICE_IDENTIFIER)},
+            manufacturer=ALARM_DEVICE_MANUFACTURER,
+            name=ALARM_DEVICE_NAME,
         )
 
 

--- a/custom_components/homematicip_local/manifest.json
+++ b/custom_components/homematicip_local/manifest.json
@@ -12,7 +12,7 @@
   "loggers": ["aiohomematic", "aiohomematic_config", "openccu_loom_client"],
   "requirements": [
     "openccu-data==2026.7.2",
-    "openccu-loom-client==2026.8.9",
+    "openccu-loom-client==2026.8.11",
     "aiohomematic-config==2026.8.0",
     "aiohomematic==2026.8.2"
   ],
@@ -22,6 +22,6 @@
       "manufacturerURL": "https://openccu.de"
     }
   ],
-  "version": "2.9.1",
+  "version": "2.9.2",
   "zeroconf": ["_openccu-loom._tcp.local."]
 }

--- a/custom_components/homematicip_local/sensor.py
+++ b/custom_components/homematicip_local/sensor.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from datetime import date, datetime
 from decimal import Decimal
 import logging
-from typing import Any, Final, cast, override
+from typing import TYPE_CHECKING, Any, Final, cast, override
 
 from aiohomematic.const import DEFAULT_MULTIPLIER, DataPointCategory, DataPointType, HubValueType, ParameterType
 from aiohomematic.interfaces import (
@@ -17,24 +17,33 @@ from aiohomematic.interfaces import (
 from aiohomematic.model.hub import SysvarDpSensor
 from aiohomematic.model.week_profile_data_point import WeekProfileDataPoint
 from homeassistant.components.sensor import RestoreSensor, SensorDeviceClass, SensorEntity, SensorStateClass
-from homeassistant.const import ATTR_CONFIG_ENTRY_ID
+from homeassistant.const import ATTR_CONFIG_ENTRY_ID, EntityCategory
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import StateType, UndefinedType
 
 from . import HomematicConfigEntry
-from .const import CLIMATE_SCHEDULE_API_VERSION, SCHEDULE_API_VERSION, HmEntityState
+from .backend_types import LOOM_DP_ALARM_CONTROL_PANEL
+from .const import CLIMATE_SCHEDULE_API_VERSION, DOMAIN, SCHEDULE_API_VERSION, HmEntityState
 from .control_unit import ControlUnit, signal_new_data_point
 from .entity_helpers import HmSensorEntityDescription
 from .generic_entity import (
     ATTR_SCHEDULE_DATA,
     ATTR_VALUE_STATE,
+    AioHomematicAlarmEntity,
     AioHomematicGenericEntity,
     AioHomematicGenericHubEntity,
     AioHomematicGenericSysvarEntity,
     get_schedule_name,
 )
+
+if TYPE_CHECKING:
+    # Typing-only: the loom twin is absent on a CCU-only install, where the
+    # dispatch tuple is empty and this entity is never constructed.
+    from openccu_loom_client.compat.aiohomematic.model.alarm_panel import LoomDpAlarmControlPanel
+
+    from aiohomematic.interfaces.model import GenericHubDataPointProtocol
 
 ATTR_CURRENT_SCHEDULE_PROFILE: Final = "active_profile"
 ATTR_AVAILABLE_PROFILES: Final = "available_profiles"
@@ -103,6 +112,19 @@ async def async_setup_entry(
         ]:
             async_add_entities(entities)
 
+    @callback
+    def async_add_alarm_triggered_motion_sensor(data_points: tuple[Any, ...]) -> None:
+        """Add a latched-detector counter per alarm panel (openccu-loom only)."""
+        _LOGGER.debug("ASYNC_ADD_ALARM_TRIGGERED_MOTION_SENSOR: Adding %i data points", len(data_points))
+
+        if entities := [
+            AioHomematicAlarmTriggeredMotionSensor(control_unit=control_unit, data_point=data_point)
+            for data_point in data_points
+            # Loom-only surface: the tuple is empty on a CCU-only install.
+            if isinstance(data_point, LOOM_DP_ALARM_CONTROL_PANEL)
+        ]:
+            async_add_entities(entities)
+
     entry.async_on_unload(
         func=async_dispatcher_connect(
             hass=hass,
@@ -124,6 +146,15 @@ async def async_setup_entry(
             target=async_add_week_profile_sensor,
         )
     )
+    # The counter rides the alarm panel data point, so it spawns off the same
+    # announce a panel does — including a zone created at runtime.
+    entry.async_on_unload(
+        func=async_dispatcher_connect(
+            hass=hass,
+            signal=signal_new_data_point(entry_id=entry.entry_id, platform=DataPointCategory.ALARM_CONTROL_PANEL),
+            target=async_add_alarm_triggered_motion_sensor,
+        )
+    )
 
     async_add_sensor(
         data_points=control_unit.get_new_data_points(
@@ -137,6 +168,10 @@ async def async_setup_entry(
         data_points=control_unit.get_new_data_points(
             data_point_type=DataPointType.SENSOR, category=DataPointCategory.WEEK_PROFILE
         )
+    )
+
+    async_add_alarm_triggered_motion_sensor(
+        data_points=control_unit.get_new_data_points(data_point_type=DataPointType.ALARM_CONTROL_PANEL)
     )
 
 
@@ -328,3 +363,65 @@ class AioHomematicWeekProfileSensor(AioHomematicGenericEntity[WeekProfileDataPoi
     def native_value(self) -> int:
         """Return the number of active schedule entries."""
         return self._data_point.value
+
+
+class AioHomematicAlarmTriggeredMotionSensor(AioHomematicAlarmEntity, SensorEntity):
+    """
+    Counts the latched detectors a motion reset would clear (openccu-loom).
+
+    The number beside the reset button, and the answer to "why will this
+    zone not arm": a detector holding its ``MOTION`` flag reads as open
+    and blocks arming until the flag clears. The master panel's counter
+    covers every zone, which is the scope its aggregate reset writes.
+
+    Diagnostic on purpose — unlike the button next to it, this reports
+    rather than acts. The count and the reset come from one daemon-side
+    predicate, so it can never name a detector the button would skip.
+    """
+
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_translation_key = "alarm_triggered_motion"
+
+    def __init__(
+        self,
+        control_unit: ControlUnit,
+        data_point: LoomDpAlarmControlPanel,
+    ) -> None:
+        """Initialize the latched-detector counter."""
+        super().__init__(
+            control_unit=control_unit,
+            # Same structural-satisfaction cast the panel platform makes:
+            # only the enum homes differ nominally.
+            data_point=cast("GenericHubDataPointProtocol", data_point),
+        )
+        # The base keys the unique id on the data point alone, which the
+        # panel entity already claims — this rides the same data point.
+        self._attr_unique_id = f"{DOMAIN}_{data_point.unique_id}_triggered_motion"
+        # One device holds every zone, so the zone has to be in the entity
+        # name or the counters are indistinguishable.
+        self._attr_translation_placeholders = {"zone": data_point.name}
+
+    @property
+    def _panel(self) -> LoomDpAlarmControlPanel:
+        """Return the data point as its concrete loom type."""
+        return cast("LoomDpAlarmControlPanel", self._data_point)
+
+    @property
+    @override
+    def name(self) -> str | UndefinedType | None:
+        """
+        Return Home Assistant's own composed name.
+
+        The hub base prefers the data point's daemon-resolved name, which
+        belongs to the *panel* this entity rides — taking it would leave
+        the counter and the panel sharing one name. This entity is named
+        by the integration, so the normal translation lookup applies.
+        """
+        return super(AioHomematicGenericHubEntity, self).name
+
+    @property
+    @override
+    def native_value(self) -> int:
+        """Return how many detectors are currently latched."""
+        return self._panel.triggered_motion_count

--- a/custom_components/homematicip_local/strings.json
+++ b/custom_components/homematicip_local/strings.json
@@ -272,6 +272,9 @@
             }
         }, 
         "button": {
+            "alarm_reset_motion": {
+                "name": "{zone} reset motion"
+            }, 
             "create_backup": {
                 "name": "Create Backup"
             }, 
@@ -369,6 +372,9 @@
         "sensor": {
             "alarm_messages": {
                 "name": "Alarm messages"
+            }, 
+            "alarm_triggered_motion": {
+                "name": "{zone} triggered motion detectors"
             }, 
             "carrier_sense_level": {
                 "name": "Carrier Sense Level"

--- a/custom_components/homematicip_local/translations/de.json
+++ b/custom_components/homematicip_local/translations/de.json
@@ -272,6 +272,9 @@
             }
         }, 
         "button": {
+            "alarm_reset_motion": {
+                "name": "{zone} Bewegung zurücksetzen"
+            }, 
             "create_backup": {
                 "name": "Backup erstellen"
             }, 
@@ -369,6 +372,9 @@
         "sensor": {
             "alarm_messages": {
                 "name": "Alarmmeldungen"
+            }, 
+            "alarm_triggered_motion": {
+                "name": "{zone} Ausgelöste Bewegungsmelder"
             }, 
             "carrier_sense_level": {
                 "name": "Carrier Sense Level"

--- a/custom_components/homematicip_local/translations/en.json
+++ b/custom_components/homematicip_local/translations/en.json
@@ -272,6 +272,9 @@
       }
     },
     "button": {
+      "alarm_reset_motion": {
+        "name": "{zone} reset motion"
+      },
       "create_backup": {
         "name": "Create Backup"
       },
@@ -369,6 +372,9 @@
     "sensor": {
       "alarm_messages": {
         "name": "Alarm messages"
+      },
+      "alarm_triggered_motion": {
+        "name": "{zone} triggered motion detectors"
       },
       "carrier_sense_level": {
         "name": "Carrier Sense Level"

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -6,7 +6,7 @@ aiohomematic==2026.8.2
 aiohomematic_config==2026.8.0
 isal==1.8.0
 openccu-data>=2026.7.2
-openccu-loom-client==2026.8.9
+openccu-loom-client==2026.8.11
 mypy<=2.1.0
 prek==0.4.13
 pur==7.4.0

--- a/tests/test_alarm.py
+++ b/tests/test_alarm.py
@@ -1,0 +1,157 @@
+"""Tests for the openccu-loom alarm surfaces (device, reset button, counter)."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.homematicip_local.button import AioHomematicAlarmMotionResetButton
+from custom_components.homematicip_local.const import (
+    ALARM_DEVICE_IDENTIFIER,
+    ALARM_DEVICE_MANUFACTURER,
+    ALARM_DEVICE_NAME,
+    DOMAIN,
+)
+from custom_components.homematicip_local.sensor import AioHomematicAlarmTriggeredMotionSensor
+
+# pylint: disable=protected-access
+
+_PANEL_UNIQUE_ID = "openccu-loom_alarm_erdgeschoss"
+
+
+def _create_mock_panel(*, zone_name: str = "Erdgeschoss", triggered_motion_count: int = 0) -> MagicMock:
+    """Create a mock LoomDpAlarmControlPanel."""
+    mock_dp = MagicMock()
+    mock_dp.unique_id = _PANEL_UNIQUE_ID
+    mock_dp.configure_mock(name=zone_name)
+    mock_dp.available = True
+    mock_dp.enabled_default = True
+    mock_dp.channel = None
+    # openccu-loom is the naming authority for the panel itself.
+    mock_dp.resolved_name = zone_name
+    mock_dp.triggered_motion_count = triggered_motion_count
+    mock_dp.reset_motion = AsyncMock(return_value=MagicMock(reset=0, failed=0))
+    return mock_dp
+
+
+def _create_entity[EntityT](entity_class: type[EntityT], *, mock_dp: MagicMock) -> EntityT:
+    """Build one alarm entity with the hub base's collaborators patched out."""
+    mock_cu = MagicMock()
+    mock_cu.central.event_bus.create_subscription_group.return_value = MagicMock()
+    with (
+        patch(
+            "custom_components.homematicip_local.generic_entity.get_data_point",
+            side_effect=lambda data_point: data_point,
+        ),
+        patch(
+            "custom_components.homematicip_local.generic_entity.get_entity_description",
+            return_value=None,
+        ),
+    ):
+        return entity_class(control_unit=mock_cu, data_point=mock_dp)  # type: ignore[call-arg]
+
+
+class TestAlarmDeviceInfo:
+    """
+    Every alarm surface lands on one device of its own, not on a CCU.
+
+    Alarm zones are daemon-level and may hold sensors of several
+    centrals, so attaching them to one central states a belonging that
+    does not exist — and buries the panels among dozens of sysvars while
+    it is at it.
+    """
+
+    @pytest.mark.parametrize(
+        "entity_class",
+        [AioHomematicAlarmMotionResetButton, AioHomematicAlarmTriggeredMotionSensor],
+    )
+    def test_alarm_entities_share_the_alarm_device(self, entity_class: type) -> None:
+        entity = _create_entity(entity_class, mock_dp=_create_mock_panel())
+        device_info = entity._attr_device_info
+        assert device_info is not None
+        assert device_info["identifiers"] == {(DOMAIN, ALARM_DEVICE_IDENTIFIER)}
+        assert device_info["name"] == ALARM_DEVICE_NAME
+        assert device_info["manufacturer"] == ALARM_DEVICE_MANUFACTURER
+
+    def test_the_identifier_matches_the_daemons_mqtt_block(self) -> None:
+        """
+        Byte-identical to `alarm_discovery.go`'s `alarmDeviceBlock`.
+
+        An installation running both bridges must see one alarm device,
+        not two describing the same zones.
+        """
+        assert ALARM_DEVICE_IDENTIFIER == "openccu-loom_alarm"
+
+
+class TestMotionResetButton:
+    """The control that ends the wait for a detector's blocking time."""
+
+    async def test_a_partial_result_warns_but_does_not_raise(self) -> None:
+        """
+        `failed > 0` means the verb ran and some detectors did not answer.
+
+        Raising would tell the operator nothing happened, when in fact
+        the rest of the zone was cleared.
+        """
+        panel = _create_mock_panel()
+        panel.reset_motion = AsyncMock(return_value=MagicMock(reset=2, failed=1))
+        button = _create_entity(AioHomematicAlarmMotionResetButton, mock_dp=panel)
+        with patch("custom_components.homematicip_local.button._LOGGER") as mock_logger:
+            await button.async_press()
+        mock_logger.warning.assert_called_once()
+
+    def test_it_is_not_a_config_entity(self) -> None:
+        """
+        openccu-loom shipped this as `config` first and nobody found it.
+
+        Home Assistant files config entities into a collapsed section of
+        the device page and keeps them out of dashboards; this is an
+        operator control.
+        """
+        button = _create_entity(AioHomematicAlarmMotionResetButton, mock_dp=_create_mock_panel())
+        assert button.entity_category is None
+
+    async def test_press_resets_the_zone(self) -> None:
+        panel = _create_mock_panel()
+        button = _create_entity(AioHomematicAlarmMotionResetButton, mock_dp=panel)
+        await button.async_press()
+        panel.reset_motion.assert_awaited_once_with()
+
+    def test_the_zone_reaches_the_entity_name(self) -> None:
+        """One device holds every zone, so the name has to carry it."""
+        button = _create_entity(
+            AioHomematicAlarmMotionResetButton, mock_dp=_create_mock_panel(zone_name="Obergeschoss")
+        )
+        assert button._attr_translation_key == "alarm_reset_motion"
+        assert button._attr_translation_placeholders == {"zone": "Obergeschoss"}
+
+    def test_unique_id_does_not_collide_with_the_panel(self) -> None:
+        """
+        The button rides the panel's data point, so the base's id is taken.
+
+        Without the suffix Home Assistant would drop whichever of the two
+        entities registered second.
+        """
+        button = _create_entity(AioHomematicAlarmMotionResetButton, mock_dp=_create_mock_panel())
+        assert button._attr_unique_id == f"{DOMAIN}_{_PANEL_UNIQUE_ID}_reset_motion"
+
+
+class TestTriggeredMotionSensor:
+    """The number beside the button — why a zone will not arm."""
+
+    def test_it_is_diagnostic(self) -> None:
+        """Unlike the button next to it, this reports rather than acts."""
+        sensor = _create_entity(AioHomematicAlarmTriggeredMotionSensor, mock_dp=_create_mock_panel())
+        assert sensor.entity_category is not None
+        assert sensor.entity_category.value == "diagnostic"
+
+    def test_it_reports_the_panel_count(self) -> None:
+        sensor = _create_entity(
+            AioHomematicAlarmTriggeredMotionSensor, mock_dp=_create_mock_panel(triggered_motion_count=3)
+        )
+        assert sensor.native_value == 3
+
+    def test_unique_id_does_not_collide_with_the_panel(self) -> None:
+        sensor = _create_entity(AioHomematicAlarmTriggeredMotionSensor, mock_dp=_create_mock_panel())
+        assert sensor._attr_unique_id == f"{DOMAIN}_{_PANEL_UNIQUE_ID}_triggered_motion"


### PR DESCRIPTION
Closes the Home Assistant half of SukramJ/openccu-loom-client#88 and all of SukramJ/openccu-loom-client#89. The client half shipped in openccu-loom-client [#90](https://github.com/SukramJ/openccu-loom-client/pull/90) and [#91](https://github.com/SukramJ/openccu-loom-client/pull/91).

> Both issues are currently filed in the `openccu-loom-client` repository, but the work in them is here. Worth moving.

## #89 — the alarm system gets a device of its own

Every alarm entity moves from the central's device onto `OpenCCU-Loom Alarm`.

The argument is not tidiness. Alarm zones are **daemon-level** and may hold sensors of several CCUs, so listing the panels under one central states a belonging that does not exist — the same reason the daemon's MQTT plane omits the `<central>` segment from its alarm topics. That it also rescued them from among dozens of system variables, programs and diagnostic values is a bonus.

**The issue's open question resolves cleanly:** `AioHomematicGenericHubEntity._get_device_info()` is a plain method, so this needed a small shared base (`AioHomematicAlarmEntity`), not a new entity hierarchy.

**On the device scope** — the identifier is the daemon's own `openccu-loom_alarm`, byte-identical to `alarm_discovery.go`'s `alarmDeviceBlock`, rather than something entry-keyed. Two reasons: an installation that also runs the MQTT bridge then sees one alarm device instead of two describing the same zones, and it matches the scope the panel unique ids already have — the daemon computes those daemon-wide (`openccu-loom_alarm_<zone>`), not per central.

## #88 — clearing latched motion detectors

A reset button per zone plus one for the aggregate, and a diagnostic counter beside each. A detector holds its `MOTION` flag until the device's own blocking time expires and reads as open until then, which blocks an arm or forces an auto-bypass with nothing to do but wait.

Presence detectors are covered too (`PRESENCE_DETECTION_STATE` → `RESET_PRESENCE`); door contacts fall out by construction. The count and the reset come from one daemon-side predicate, so the number can never name a detector the button would skip.

**Both entities ride the alarm panel data point.** That is what buys the behaviour for free: they inherit its availability, its refresh subscription and its removal when a zone disappears, and they spawn off the same announce a panel does — including a zone created at runtime. It also has two consequences worth naming, because both are non-obvious in the diff:

- the base keys the unique id on the data point alone, which the panel entity already claims — hence the explicit `_reset_motion` / `_triggered_motion` suffixes;
- the base prefers the data point's daemon-resolved name, which belongs to the *panel* — taking it would leave all three entities of a zone sharing one name, hence the `name` override that falls back to Home Assistant's own translation lookup.

**The button is deliberately not a config entity.** The issue is explicit about this and it is worth repeating: openccu-loom shipped it as `config` first and nobody found it, because Home Assistant files config entities into a collapsed section of the device page and keeps them out of dashboards. This is an operator control. Only the counter is diagnostic.

**A partial reset warns rather than raises.** `failed > 0` means the verb ran and some detectors did not answer; raising would tell the operator nothing happened when in fact the rest of the zone was cleared.

## Naming

One device holds every zone, so the zone has to appear in the entity name or the buttons are indistinguishable. Both entities use `translation_key` + `translation_placeholders={"zone": …}`, mirroring the daemon's own MQTT naming. New keys in `strings.json`, `en.json` and `de.json`.

## Dependency

`openccu-loom-client` → **2026.8.11**, in both `manifest.json` and `requirements_test.txt`.

**This raises the daemon floor: the client refuses to connect to an openccu-loom below 0.58.3.** Installations on an older daemon should stay on 2.9.1 until the daemon is updated. Motion reset itself additionally wants ≥ 0.58.1 — 0.58.0 shipped the routes but a type assertion made them inert on real hardware, so a setup on exactly that release would see the button do nothing and the counter read 0.

## Verification

- `make test` — 892 passed, 8 skipped (11 new in `tests/test_alarm.py`, the first tests for the loom alarm surface in this repo)
- `make mypy` — no issues in 62 source files
- `make prek` — every hook green, including `check-translations` and `sort-class-members`
- `make translations` / `make flow-translations` — OK

## Note on the dev environment

The `venv` was two dependency bumps behind and produced four failures in `test_init.py` / `test_diagnostics.py` that had nothing to do with this change (`aiohomematic` 2026.8.1 installed against the 2026.8.2 manifest pin, and `openccu-loom-client` 2026.8.2 against a 2026.8.9 pin). I aligned it before trusting any result. Worth a `make install` on other machines.
