### PR TITLE
fix(alarm): name the reset button and its counter — 2.9.2

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,18 +4,13 @@
 
 ### Development
 
-- The openccu-loom alarm system (Beta) gets a device of its own, `OpenCCU-Loom Alarm`, and every alarm entity moves onto it. Alarm zones are daemon-level and may hold sensors of several CCUs, so listing the panels under one central stated a belonging that does not exist — and buried them among dozens of system variables, programs and diagnostic values. The device identifier is the daemon's own, so an installation that also runs the daemon's MQTT bridge sees one alarm device rather than two describing the same zones ([#89](https://github.com/SukramJ/openccu-loom-client/issues/89))
-- Latched motion detectors can be cleared from Home Assistant: a reset button per alarm zone plus one for the aggregate, and a diagnostic counter beside each. A motion detector holds its `MOTION` flag until the device's own blocking time expires, and reads as open until then — which blocks an arm or forces an auto-bypass with nothing to do but wait. The button ends the wait; the counter answers why a zone will not arm. Presence detectors are covered too, door contacts fall out by construction. Requires an openccu-loom daemon ≥ 0.58.1 — 0.58.0 shipped the routes but they were inert on real hardware ([#88](https://github.com/SukramJ/openccu-loom-client/issues/88))
-- The reset button is deliberately a plain control, not a config entity: the daemon shipped it as `config` first and nobody found it, because Home Assistant files such entities into a collapsed section of the device page and keeps them out of dashboards. Only the counter is diagnostic
-- The user-facing details of the loom backend stay out of scope for this changelog until it leaves Beta
+- This release is openccu-loom backend (Beta) work only; the direct-CCU backend is unchanged. The user-facing details of the loom backend stay out of scope for this changelog until it leaves Beta
 
 ### Dependencies
 
-#### Bump openccu-loom-client to `2026.8.11` (pins `openccu-loom-types==0.3.14`)
+#### Bump openccu-loom-client to `2026.8.12` (pins `openccu-loom-types==0.3.14`)
 
-- Adds the alarm motion-reset surface the two entities above are built on: the REST verbs, `AlarmPanel.reset_motion()`, and the per-zone latched-detector count
-- The count is refreshed by re-reading rather than pushed — the daemon broadcasts no latch event — and the client schedules that read off the alarm events that can plausibly move a latch, coalescing bursts into one call
-- **This raises the daemon floor: the client refuses to connect to an openccu-loom below 0.58.3.** Installations on an older daemon should stay on 2.9.1 until the daemon is updated
+- Bump for the openccu-loom backend (Beta); it has no runtime effect on the direct-CCU backend, where the client is not loaded. Advances the bundled loom client from `2026.8.9` to `2026.8.12` and its transitively pinned `openccu-loom-types` from `0.3.10` to `0.3.14`. **It raises the minimum daemon to openccu-loom 0.58.3 or newer** — the client refuses to connect to a lower API minor rather than half-initializing against it. Installations on an older daemon should stay on 2.9.1 until the daemon is updated
 
 # Version [2.9.1](https://github.com/SukramJ/homematicip_local/compare/2.9.0...2.9.1) (2026-08-10)
 

--- a/custom_components/homematicip_local/button.py
+++ b/custom_components/homematicip_local/button.py
@@ -199,8 +199,8 @@ class AioHomematicAlarmMotionResetButton(AioHomematicAlarmEntity, ButtonEntity):
         # panel entity already claims — this rides the same data point.
         self._attr_unique_id = f"{DOMAIN}_{data_point.unique_id}_reset_motion"
         # One device holds every zone, so the zone has to be in the entity
-        # name or the buttons are indistinguishable. Mirrors the daemon's
-        # own MQTT naming ("<zone> — Reset motion").
+        # name or the buttons are indistinguishable. Only used when the
+        # daemon's own name is unavailable — see `name`.
         self._attr_translation_placeholders = {"zone": data_point.name}
 
     @property
@@ -212,13 +212,27 @@ class AioHomematicAlarmMotionResetButton(AioHomematicAlarmEntity, ButtonEntity):
     @override
     def name(self) -> str | UndefinedType | None:
         """
-        Return Home Assistant's own composed name.
+        Return the daemon's name for this button, else compose one here.
 
-        The hub base prefers the data point's daemon-resolved name, which
-        belongs to the *panel* this entity rides — taking it would leave
-        the button and the panel sharing one name. This entity is named by
-        the integration, so the normal translation lookup applies.
+        openccu-loom is the naming authority for its own entities and has
+        named this button in its i18n catalogue all along — the words
+        just never left the MQTT discovery plane, so this integration
+        wrote them a second time. Rendering the daemon's copy is what
+        keeps a zone reading the same whether Home Assistant learned it
+        through this backend or through the daemon's MQTT bridge.
+
+        The fallback below is the local translation, which a daemon
+        without the catalogue route leaves in charge. Note what is *not*
+        used: the hub base prefers the data point's own resolved name,
+        and that name belongs to the *panel* this entity rides — taking
+        it would leave the button and the panel sharing one name.
+
+        The isinstance check is not belt-and-braces: `getattr` on a mock
+        answers with a truthy mock, and a bare truthiness test would make
+        every mocked panel in a test suite take this branch.
         """
+        if isinstance(daemon_name := self._panel.reset_motion_name, str) and daemon_name:
+            return daemon_name
         return super(AioHomematicGenericHubEntity, self).name
 
     @handle_homematic_errors

--- a/custom_components/homematicip_local/generic_entity.py
+++ b/custom_components/homematicip_local/generic_entity.py
@@ -502,7 +502,14 @@ class AioHomematicGenericHubEntity(Entity):
             self._attr_entity_registry_enabled_default = data_point.enabled_default
             if isinstance(data_point, GenericSysvarDataPointProtocol):
                 self._attr_translation_key = data_point.name.lower()
-            else:
+            elif getattr(self, "_attr_translation_key", None) is None:
+                # A subclass that declares its own translation key names itself
+                # out of this integration's catalogue. Setting `_attr_name` here
+                # would silently win over that: `Entity.name` hands the attribute
+                # back before it ever looks a key up. Entities riding another
+                # entity's data point — the alarm reset button and its counter
+                # ride the panel — would end up named after that data point,
+                # indistinguishable from the entity they accompany.
                 self._attr_name = data_point.name
 
         self._attr_device_info = self._get_device_info()

--- a/custom_components/homematicip_local/manifest.json
+++ b/custom_components/homematicip_local/manifest.json
@@ -12,7 +12,7 @@
   "loggers": ["aiohomematic", "aiohomematic_config", "openccu_loom_client"],
   "requirements": [
     "openccu-data==2026.7.2",
-    "openccu-loom-client==2026.8.11",
+    "openccu-loom-client==2026.8.12",
     "aiohomematic-config==2026.8.0",
     "aiohomematic==2026.8.2"
   ],

--- a/custom_components/homematicip_local/sensor.py
+++ b/custom_components/homematicip_local/sensor.py
@@ -399,7 +399,8 @@ class AioHomematicAlarmTriggeredMotionSensor(AioHomematicAlarmEntity, SensorEnti
         # panel entity already claims — this rides the same data point.
         self._attr_unique_id = f"{DOMAIN}_{data_point.unique_id}_triggered_motion"
         # One device holds every zone, so the zone has to be in the entity
-        # name or the counters are indistinguishable.
+        # name or the counters are indistinguishable. Only used when the
+        # daemon's own name is unavailable — see `name`.
         self._attr_translation_placeholders = {"zone": data_point.name}
 
     @property
@@ -411,13 +412,15 @@ class AioHomematicAlarmTriggeredMotionSensor(AioHomematicAlarmEntity, SensorEnti
     @override
     def name(self) -> str | UndefinedType | None:
         """
-        Return Home Assistant's own composed name.
+        Return the daemon's name for this counter, else compose one here.
 
-        The hub base prefers the data point's daemon-resolved name, which
-        belongs to the *panel* this entity rides — taking it would leave
-        the counter and the panel sharing one name. This entity is named
-        by the integration, so the normal translation lookup applies.
+        Same naming authority as the button beside it — see
+        `AioHomematicAlarmMotionResetButton.name` for why the daemon's
+        copy wins, why the local translation is the fallback rather than
+        the rule, and why the panel's own resolved name is not used.
         """
+        if isinstance(daemon_name := self._panel.triggered_motion_name, str) and daemon_name:
+            return daemon_name
         return super(AioHomematicGenericHubEntity, self).name
 
     @property

--- a/custom_components/homematicip_local/strings.json
+++ b/custom_components/homematicip_local/strings.json
@@ -273,7 +273,7 @@
         }, 
         "button": {
             "alarm_reset_motion": {
-                "name": "{zone} reset motion"
+                "name": "{zone} — Reset motion"
             }, 
             "create_backup": {
                 "name": "Create Backup"
@@ -374,7 +374,7 @@
                 "name": "Alarm messages"
             }, 
             "alarm_triggered_motion": {
-                "name": "{zone} triggered motion detectors"
+                "name": "{zone} — Triggered motion detectors"
             }, 
             "carrier_sense_level": {
                 "name": "Carrier Sense Level"

--- a/custom_components/homematicip_local/translations/de.json
+++ b/custom_components/homematicip_local/translations/de.json
@@ -273,7 +273,7 @@
         }, 
         "button": {
             "alarm_reset_motion": {
-                "name": "{zone} Bewegung zurücksetzen"
+                "name": "{zone} — Bewegung zurücksetzen"
             }, 
             "create_backup": {
                 "name": "Backup erstellen"
@@ -374,7 +374,7 @@
                 "name": "Alarmmeldungen"
             }, 
             "alarm_triggered_motion": {
-                "name": "{zone} Ausgelöste Bewegungsmelder"
+                "name": "{zone} — Ausgelöste Bewegungsmelder"
             }, 
             "carrier_sense_level": {
                 "name": "Carrier Sense Level"

--- a/custom_components/homematicip_local/translations/en.json
+++ b/custom_components/homematicip_local/translations/en.json
@@ -273,7 +273,7 @@
     },
     "button": {
       "alarm_reset_motion": {
-        "name": "{zone} reset motion"
+        "name": "{zone} — Reset motion"
       },
       "create_backup": {
         "name": "Create Backup"
@@ -374,7 +374,7 @@
         "name": "Alarm messages"
       },
       "alarm_triggered_motion": {
-        "name": "{zone} triggered motion detectors"
+        "name": "{zone} — Triggered motion detectors"
       },
       "carrier_sense_level": {
         "name": "Carrier Sense Level"

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -6,7 +6,7 @@ aiohomematic==2026.8.2
 aiohomematic_config==2026.8.0
 isal==1.8.0
 openccu-data>=2026.7.2
-openccu-loom-client==2026.8.11
+openccu-loom-client==2026.8.12
 mypy<=2.1.0
 prek==0.4.13
 pur==7.4.0

--- a/tests/test_alarm.py
+++ b/tests/test_alarm.py
@@ -20,8 +20,20 @@ from custom_components.homematicip_local.sensor import AioHomematicAlarmTriggere
 _PANEL_UNIQUE_ID = "openccu-loom_alarm_erdgeschoss"
 
 
-def _create_mock_panel(*, zone_name: str = "Erdgeschoss", triggered_motion_count: int = 0) -> MagicMock:
-    """Create a mock LoomDpAlarmControlPanel."""
+def _create_mock_panel(
+    *,
+    zone_name: str = "Erdgeschoss",
+    triggered_motion_count: int = 0,
+    daemon_names: bool = False,
+) -> MagicMock:
+    """
+    Create a mock LoomDpAlarmControlPanel.
+
+    ``daemon_names`` decides whether the daemon's entity-name catalogue
+    reached the client: without it the panel answers ``None`` for both
+    companion names, which is what a daemon older than api 5.2.0 leaves
+    behind.
+    """
     mock_dp = MagicMock()
     mock_dp.unique_id = _PANEL_UNIQUE_ID
     mock_dp.configure_mock(name=zone_name)
@@ -32,6 +44,8 @@ def _create_mock_panel(*, zone_name: str = "Erdgeschoss", triggered_motion_count
     mock_dp.resolved_name = zone_name
     mock_dp.triggered_motion_count = triggered_motion_count
     mock_dp.reset_motion = AsyncMock(return_value=MagicMock(reset=0, failed=0))
+    mock_dp.reset_motion_name = f"{zone_name} — Bewegung zurücksetzen" if daemon_names else None
+    mock_dp.triggered_motion_name = f"{zone_name} — Ausgelöste Bewegungsmelder" if daemon_names else None
     return mock_dp
 
 
@@ -118,6 +132,35 @@ class TestMotionResetButton:
         await button.async_press()
         panel.reset_motion.assert_awaited_once_with()
 
+    def test_the_daemon_names_the_button(self) -> None:
+        """
+        openccu-loom is the naming authority for its own entities.
+
+        The same words live in the daemon's i18n catalogue and in this
+        integration's `strings.json`; rendering the daemon's copy is what
+        keeps a zone reading identically whether Home Assistant learned it
+        through this backend or through the daemon's MQTT bridge.
+        """
+        button = _create_entity(
+            AioHomematicAlarmMotionResetButton,
+            mock_dp=_create_mock_panel(zone_name="Obergeschoss", daemon_names=True),
+        )
+        assert button.name == "Obergeschoss — Bewegung zurücksetzen"
+
+    def test_the_translated_name_is_not_shadowed(self) -> None:
+        """
+        A translation key alone does not name an entity.
+
+        `Entity.name` hands back `_attr_name` before it ever consults the
+        catalogue, and the hub base sets that attribute from the data
+        point — which here is the *panel* this button rides. Left in
+        place it leaves the button, the counter and the panel all called
+        after the bare zone, and it would shadow the local fallback the
+        moment the daemon has no name to offer.
+        """
+        button = _create_entity(AioHomematicAlarmMotionResetButton, mock_dp=_create_mock_panel())
+        assert not hasattr(button, "_attr_name")
+
     def test_the_zone_reaches_the_entity_name(self) -> None:
         """One device holds every zone, so the name has to carry it."""
         button = _create_entity(
@@ -151,6 +194,32 @@ class TestTriggeredMotionSensor:
             AioHomematicAlarmTriggeredMotionSensor, mock_dp=_create_mock_panel(triggered_motion_count=3)
         )
         assert sensor.native_value == 3
+
+    def test_the_daemon_names_the_counter(self) -> None:
+        """Same naming authority as the button beside it."""
+        sensor = _create_entity(
+            AioHomematicAlarmTriggeredMotionSensor,
+            mock_dp=_create_mock_panel(zone_name="Obergeschoss", daemon_names=True),
+        )
+        assert sensor.name == "Obergeschoss — Ausgelöste Bewegungsmelder"
+
+    def test_the_translated_name_is_not_shadowed(self) -> None:
+        """
+        Same shadowing as the button beside it — see that test.
+
+        A counter named after the bare zone is worse than useless on the
+        diagnostics list: three of them, all reading like the panels.
+        """
+        sensor = _create_entity(AioHomematicAlarmTriggeredMotionSensor, mock_dp=_create_mock_panel())
+        assert not hasattr(sensor, "_attr_name")
+
+    def test_the_zone_reaches_the_entity_name(self) -> None:
+        """One device holds every zone, so the name has to carry it."""
+        sensor = _create_entity(
+            AioHomematicAlarmTriggeredMotionSensor, mock_dp=_create_mock_panel(zone_name="Obergeschoss")
+        )
+        assert sensor._attr_translation_key == "alarm_triggered_motion"
+        assert sensor._attr_translation_placeholders == {"zone": "Obergeschoss"}
 
     def test_unique_id_does_not_collide_with_the_panel(self) -> None:
         sensor = _create_entity(AioHomematicAlarmTriggeredMotionSensor, mock_dp=_create_mock_panel())


### PR DESCRIPTION
The motion-reset buttons and the latched-detector counters added in 2.9.2 shipped named after their bare alarm zone — three buttons and three diagnostic sensors reading like the panels they accompany, on a device that holds every zone.

## Why the names never appeared

The translation keys were there and correct, and never consulted. `AioHomematicGenericHubEntity` sets `_attr_name` from its data point, and Home Assistant's `Entity.name` hands that attribute back before it ever looks a key up — so for the two entities that ride the alarm panel's data point, the panel's name won:

```
AioHomematicAlarmMotionResetButton:      attr_name='Erdgeschoss' tkey='alarm_reset_motion'      name='Erdgeschoss'
AioHomematicAlarmTriggeredMotionSensor:  attr_name='Erdgeschoss' tkey='alarm_triggered_motion'  name='Erdgeschoss'
```

The base now leaves `_attr_name` alone when the subclass declares a translation key of its own. Nothing else on that base does, so nothing else changes.

## Where the names come from now

That fixed the fallback. The names themselves now come from the daemon, which is the naming authority for its own entities (ADR 0046) and has carried these two words in its i18n catalogue all along — `discovery.alarm_reset_motion` and `discovery.alarm_triggered_motion`. They simply never left the MQTT discovery plane, which is why they were written a second time here.

The entities render `AlarmPanel.reset_motion_name` / `.triggered_motion_name`, already composed as `<zone> — <label>`. The local translation stays as the fallback for a daemon that does not serve `GET /i18n/entities`, and now carries the same separator, so the two readings no longer differ by punctuation.

The `EntityCategory` is deliberately unchanged: the daemon's own zone-level button carries no category either (`alarm_discovery.go`, same reasoning). The `config`-classified `RESET_MOTION` is the per-device parameter button, a different entity on a different level.

## Depends on

**openccu-loom-client 2026.8.12 — SukramJ/openccu-loom-client#92.** It adds the two properties and lands the catalogue in the store, so a zone created at runtime is named like the rest and a renamed zone renames its companions. **CI here fails until that release is on PyPI**; the manifest and `requirements_test.txt` already pin it.

## Changelog

2.9.2 drops the loom entity details and keeps the shape 2.9.1 established: the backend is Beta, its user-facing details stay out until it leaves Beta, and the dependency bump keeps the daemon-floor warning a Beta installation needs.

## Verification

- `make test-cov` — 897 passed, 8 skipped
- `make prek` — clean (against a locally built 2026.8.12 wheel)
- New tests: the daemon name wins for both entities, and `_attr_name` stays unset so the local fallback is reachable at all
