### PR TITLE
chore(deps): aiohomematic 2026.8.3, openccu-loom-client 2026.8.13 — 2.9.2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
         types_or: [python]
         files: ^(custom_components/homematicip_local|tests)/.+\.py$
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.16.2
+    rev: v0.16.3
     hooks:
       - id: ruff
         args:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,20 +118,21 @@ homematicip_local/
 
 ### Runtime Dependencies
 
-- **aiohomematic** (v2026.8.2) - Core async library for Homematic device communication
+- **aiohomematic** (v2026.8.3) - Core async library for Homematic device communication
 - **aiohomematic-config** (v2026.8.0) - Device configuration metadata
+- **openccu-loom-client** (v2026.8.13) - Client for the openccu-loom backend (Beta)
 - **Home Assistant Core** - Minimum version: 2026.7.0+
 - **Python 3.14+** (target version for development)
 
 ### Development Dependencies
 
-- **pytest-homeassistant-custom-component-framework** (1.0.25) - HA test framework
+- **pytest-homeassistant-custom-component-framework** (1.0.45) - HA test framework
 - **mypy** (2.1.0) - Static type checker (strict mode)
-- **pylint** (4.0.5) - Code linting
-- **ruff** (0.15.15) - Fast Python linter and formatter
-- **prek** (0.4.4) - Git hooks manager (Rust-based pre-commit alternative)
-- **aiohomematic-test-support** (2026.8.1) - Mock test data
-- **async-upnp-client** (0.47.0) - UPnP discovery
+- **pylint** (4.0.7) - Code linting
+- **ruff** (0.16.3) - Fast Python linter and formatter
+- **prek** (0.4.13) - Git hooks manager (Rust-based pre-commit alternative)
+- **aiohomematic-test-support** (2026.8.3) - Mock test data
+- **async-upnp-client** (0.48.0) - UPnP discovery
 - **uv** - Fast Python package installer (preferred over pip)
 
 ---
@@ -1126,7 +1127,8 @@ make hass
 - **Current Version:** 2.9.2
 - **Minimum HA Version:** 2026.7.0+
 - **Python Target:** 3.14+ (CI tests on 3.14)
-- **aiohomematic Version:** 2026.8.2
+- **aiohomematic Version:** 2026.8.3
+- **openccu-loom-client Version:** 2026.8.13 (requires an openccu-loom daemon ≥ 0.61.1)
 
 ### External Resources
 
@@ -1139,5 +1141,5 @@ make hass
 
 ---
 
-**Last Updated**: 2026-08-12
+**Last Updated**: 2026-08-16
 **Version**: 2.9.2

--- a/changelog.md
+++ b/changelog.md
@@ -1,16 +1,22 @@
-# Version [2.9.2](https://github.com/SukramJ/homematicip_local/compare/2.9.1...2.9.2) (2026-08-12)
+# Version [2.9.2](https://github.com/SukramJ/homematicip_local/compare/2.9.1...2.9.2) (2026-08-16)
 
 ## What's Changed
 
 ### Development
 
-- This release is openccu-loom backend (Beta) work only; the direct-CCU backend is unchanged. The user-facing details of the loom backend stay out of scope for this changelog until it leaves Beta
+- The integration's own changes in this release are openccu-loom backend (Beta) work; the direct-CCU backend gains support for two new devices through the aiohomematic bump below. The user-facing details of the loom backend stay out of scope for this changelog until it leaves Beta
 
 ### Dependencies
 
-#### Bump openccu-loom-client to `2026.8.12` (pins `openccu-loom-types==0.3.14`)
+#### Bump aiohomematic to [2026.8.3](https://github.com/SukramJ/aiohomematic/compare/2026.8.2...2026.8.3)
 
-- Bump for the openccu-loom backend (Beta); it has no runtime effect on the direct-CCU backend, where the client is not loaded. Advances the bundled loom client from `2026.8.9` to `2026.8.12` and its transitively pinned `openccu-loom-types` from `0.3.10` to `0.3.14`. **It raises the minimum daemon to openccu-loom 0.58.3 or newer** — the client refuses to connect to a lower API minor rather than half-initializing against it. Installations on an older daemon should stay on 2.9.1 until the daemon is updated
+- Add support for the flush-mount switch actuators `HmIP-FS6` and `HmIP-FSI6`. `HmIP-FS6` has no input channel, so it shares the channel layout of `HmIP-FSM` and is now registered as a switch profile on channel 2 — without that registration it only produced generic data points. `OPERATING_VOLTAGE` is ignored for it as well, consistent with the other mains-powered actuators
+- Expose `CHANNEL_OPERATION_MODE` on channel 1 of `HmIP-FSI6`. The custom switch data point of that device already worked, but the un-ignore rule was keyed on `HmIP-FSI16` only — model keys are matched with `str.startswith`, and `"hmip-fsi6".startswith("hmip-fsi16")` is `False`, so the operation mode of the push-button input stayed hidden
+
+#### Bump openccu-loom-client to `2026.8.13` (pins `openccu-loom-types==0.4.0`)
+
+- Bump for the openccu-loom backend (Beta); it has no runtime effect on the direct-CCU backend, where the client is not loaded. Advances the bundled loom client from `2026.8.9` to `2026.8.13` and its transitively pinned `openccu-loom-types` from `0.3.10` to `0.4.0`
+- **This raises the minimum daemon to openccu-loom 0.61.1 or newer.** The daemon's API major went from 5 to 6, and the client refuses to connect across a major rather than half-initializing against an incompatible daemon — so unlike the previous bumps, an older daemon is now rejected outright rather than merely missing newer surface. Installations that cannot update the daemon should stay on 2.9.1
 
 # Version [2.9.1](https://github.com/SukramJ/homematicip_local/compare/2.9.0...2.9.1) (2026-08-10)
 

--- a/custom_components/homematicip_local/manifest.json
+++ b/custom_components/homematicip_local/manifest.json
@@ -12,9 +12,9 @@
   "loggers": ["aiohomematic", "aiohomematic_config", "openccu_loom_client"],
   "requirements": [
     "openccu-data==2026.7.2",
-    "openccu-loom-client==2026.8.12",
+    "openccu-loom-client==2026.8.13",
     "aiohomematic-config==2026.8.0",
-    "aiohomematic==2026.8.2"
+    "aiohomematic==2026.8.3"
   ],
   "ssdp": [
     {

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,15 +1,15 @@
 -r requirements_test_pre_commit.txt
 
 async_upnp_client==0.48.0
-aiohomematic-test-support==2026.8.2
-aiohomematic==2026.8.2
+aiohomematic-test-support==2026.8.3
+aiohomematic==2026.8.3
 aiohomematic_config==2026.8.0
 isal==1.8.0
 openccu-data>=2026.7.2
-openccu-loom-client==2026.8.12
+openccu-loom-client==2026.8.13
 mypy<=2.1.0
 prek==0.4.13
 pur==7.4.0
 pylint==4.0.7
 pylint_strict_informational==0.1
-pytest-homeassistant-custom-component-framework==1.0.44
+pytest-homeassistant-custom-component-framework==1.0.45

--- a/requirements_test_pre_commit.txt
+++ b/requirements_test_pre_commit.txt
@@ -1,5 +1,5 @@
 bandit==1.9.4
 codespell==2.4.3
 python-typing-update==v0.8.1
-ruff==0.16.2
+ruff==0.16.3
 yamllint==1.38.0


### PR DESCRIPTION
Two dependency bumps and the 2.9.2 release note that goes with them.

## aiohomematic 2026.8.3

The only part of this release that reaches the direct-CCU backend:

- **`HmIP-FS6` / `HmIP-FSI6` support.** `FS6` has no input channel, so it shares `HmIP-FSM`'s layout and is now registered as a switch profile on channel 2 — without that registration it only produced generic data points.
- **`CHANNEL_OPERATION_MODE` on channel 1 of `HmIP-FSI6`.** The un-ignore rule was keyed on `HmIP-FSI16` alone, and model keys match with `str.startswith` — `"hmip-fsi6".startswith("hmip-fsi16")` is `False`, so the push-button input's operation mode stayed hidden.

## openccu-loom-client 2026.8.13 (pins `openccu-loom-types==0.4.0`)

Syncs the loom backend (Beta) to daemon 0.61.1 / api 6.1.0. **This one is not a routine bump:** the daemon's API major went 5 → 6, and the client refuses to connect across a major. A Beta installation on an older daemon is therefore rejected outright rather than merely missing newer surface — the previous bumps could be read as "you keep what you had", and this one cannot. The changelog states it in those terms.

No runtime effect on the direct-CCU backend, where the client is not loaded.

## Changelog

The loom entity details stay out until the backend leaves Beta, so the note keeps the shape 2.9.1 established: what the integration itself changed in one line, the dependency bumps below it. The Development line no longer claims the direct-CCU backend is unchanged — the two new devices reach it. Release date moved to today; 2.9.2 is so far tagged only as `2.9.2b0` / `2.9.2b1`.

## CLAUDE.md

The version tables had drifted well past this bump — `pytest-homeassistant-custom-component-framework` (1.0.25 → 1.0.45), `pylint` (4.0.5 → 4.0.7), `ruff` (0.15.15 → 0.16.3), `prek` (0.4.4 → 0.4.13), `aiohomematic-test-support` (2026.8.1 → 2026.8.3) and `async-upnp-client` (0.47.0 → 0.48.0) all named releases older than the pins they document. Refreshed against the actual requirements files. `openccu-loom-client` is listed there for the first time, with the daemon floor beside it.

## Also riding along

Dev pins already in the working tree: `ruff` 0.16.3 (hook and requirement kept in lock-step) and the test framework 1.0.45.

## Verification

- `make test-cov` — 897 passed, 8 skipped
- `make prek` — clean
