### PR TITLE
fix(button): keep the backup button available after the central starts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ This document provides comprehensive guidance for AI assistants working with the
 
 **Project Name:** Homematic(IP) Local for OpenCCU
 **Type:** Home Assistant Custom Integration
-**Version:** 2.9.2
+**Version:** 2.9.3
 **Primary Language:** Python 3.14+
 **Domain:** `homematicip_local`
 
@@ -1124,7 +1124,7 @@ make hass
 
 ### Version Information
 
-- **Current Version:** 2.9.2
+- **Current Version:** 2.9.3
 - **Minimum HA Version:** 2026.7.0+
 - **Python Target:** 3.14+ (CI tests on 3.14)
 - **aiohomematic Version:** 2026.8.3
@@ -1141,5 +1141,5 @@ make hass
 
 ---
 
-**Last Updated**: 2026-08-16
-**Version**: 2.9.2
+**Last Updated**: 2026-08-17
+**Version**: 2.9.3

--- a/changelog.md
+++ b/changelog.md
@@ -1,14 +1,10 @@
-# Version [2.9.3](https://github.com/SukramJ/homematicip_local/compare/2.9.2...2.9.3) (2026-08-17)
+# Version [2.9.2](https://github.com/SukramJ/homematicip_local/compare/2.9.1...2.9.2) (2026-08-17)
 
 ## What's Changed
 
 ### Bug Fixes
 
 - Fix the "Create backup" button staying `unavailable` forever on the openccu-loom backend (Beta). Home Assistant sets the button up before the central is started, so it read `unavailable` at add time; with no data point, no polling and no subscription it never re-evaluated — and the loom backend reaches its running state without emitting a state event, so nothing prompted a refresh. The control unit now fans out a central-state-changed signal once the central has started and on every later transition, and the button re-renders on it (#579). The direct-CCU backend was unaffected
-
-# Version [2.9.2](https://github.com/SukramJ/homematicip_local/compare/2.9.1...2.9.2) (2026-08-16)
-
-## What's Changed
 
 ### Development
 
@@ -21,10 +17,10 @@
 - Add support for the flush-mount switch actuators `HmIP-FS6` and `HmIP-FSI6`. `HmIP-FS6` has no input channel, so it shares the channel layout of `HmIP-FSM` and is now registered as a switch profile on channel 2 — without that registration it only produced generic data points. `OPERATING_VOLTAGE` is ignored for it as well, consistent with the other mains-powered actuators
 - Expose `CHANNEL_OPERATION_MODE` on channel 1 of `HmIP-FSI6`. The custom switch data point of that device already worked, but the un-ignore rule was keyed on `HmIP-FSI16` only — model keys are matched with `str.startswith`, and `"hmip-fsi6".startswith("hmip-fsi16")` is `False`, so the operation mode of the push-button input stayed hidden
 
-#### Bump openccu-loom-client to `2026.8.13` (pins `openccu-loom-types==0.4.0`)
+#### Bump openccu-loom-client to `2026.8.18` (pins `openccu-loom-types==0.4.2`)
 
-- Bump for the openccu-loom backend (Beta); it has no runtime effect on the direct-CCU backend, where the client is not loaded. Advances the bundled loom client from `2026.8.9` to `2026.8.13` and its transitively pinned `openccu-loom-types` from `0.3.10` to `0.4.0`
-- **This raises the minimum daemon to openccu-loom 0.61.1 or newer.** The daemon's API major went from 5 to 6, and the client refuses to connect across a major rather than half-initializing against an incompatible daemon — so unlike the previous bumps, an older daemon is now rejected outright rather than merely missing newer surface. Installations that cannot update the daemon should stay on 2.9.1
+- Bump for the openccu-loom backend (Beta); it has no runtime effect on the direct-CCU backend, where the client is not loaded. Advances the bundled loom client from `2026.8.9` to `2026.8.18` and its transitively pinned `openccu-loom-types` from `0.3.10` to `0.4.2`
+- **This raises the minimum daemon to openccu-loom 0.61.3 or newer.** The daemon's API major went from 5 to 6 and the client is generated against API 6.2, so it refuses to connect to a daemon reporting an older API (a different major, or major 6 below minor 2) rather than half-initializing against an incompatible daemon — an older daemon is rejected outright rather than merely missing newer surface. Installations that cannot update the daemon should stay on 2.9.1
 
 # Version [2.9.1](https://github.com/SukramJ/homematicip_local/compare/2.9.0...2.9.1) (2026-08-10)
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,11 @@
+# Version [2.9.3](https://github.com/SukramJ/homematicip_local/compare/2.9.2...2.9.3) (2026-08-17)
+
+## What's Changed
+
+### Bug Fixes
+
+- Fix the "Create backup" button staying `unavailable` forever on the openccu-loom backend (Beta). Home Assistant sets the button up before the central is started, so it read `unavailable` at add time; with no data point, no polling and no subscription it never re-evaluated — and the loom backend reaches its running state without emitting a state event, so nothing prompted a refresh. The control unit now fans out a central-state-changed signal once the central has started and on every later transition, and the button re-renders on it (#579). The direct-CCU backend was unaffected
+
 # Version [2.9.2](https://github.com/SukramJ/homematicip_local/compare/2.9.1...2.9.2) (2026-08-16)
 
 ## What's Changed

--- a/custom_components/homematicip_local/button.py
+++ b/custom_components/homematicip_local/button.py
@@ -20,7 +20,7 @@ from homeassistant.helpers.typing import UndefinedType
 from . import HomematicConfigEntry
 from .backend_types import LOOM_DP_ALARM_CONTROL_PANEL
 from .const import DOMAIN
-from .control_unit import ControlUnit, signal_new_data_point
+from .control_unit import ControlUnit, signal_central_state_changed, signal_new_data_point
 from .generic_entity import (
     ATTR_DESCRIPTION,
     ATTR_NAME,
@@ -274,6 +274,26 @@ class HmipLocalCreateBackupButton(ButtonEntity):
         return self._cu.central.available
 
     @override
+    async def async_added_to_hass(self) -> None:
+        """Re-evaluate availability whenever the central's state changes.
+
+        Home Assistant sets this platform up before the central is started, so
+        at add time the central is still stopped and ``available`` reads False.
+        This entity rides no data point and does not poll, so without a
+        subscription it would keep that first reading forever — across restarts
+        and reloads. The control unit fans a signal out once the central has
+        started and on every later state transition; re-render on each.
+        """
+        await super().async_added_to_hass()
+        self.async_on_remove(
+            async_dispatcher_connect(
+                hass=self.hass,
+                signal=signal_central_state_changed(entry_id=self._cu.entry_id),
+                target=self._async_central_state_changed,
+            )
+        )
+
+    @override
     async def async_press(self) -> None:
         """Handle the button press."""
         try:
@@ -294,3 +314,8 @@ class HmipLocalCreateBackupButton(ButtonEntity):
             _LOGGER.info("CCU backup saved to %s (%d bytes)", backup_path, len(backup_data.content))
         except BaseHomematicException as err:
             raise HomeAssistantError(f"Failed to create CCU backup: {err}") from err
+
+    @callback
+    def _async_central_state_changed(self) -> None:
+        """Write the entity state after the central's availability may have changed."""
+        self.async_write_ha_state()

--- a/custom_components/homematicip_local/control_unit.py
+++ b/custom_components/homematicip_local/control_unit.py
@@ -437,6 +437,12 @@ class ControlUnit(BaseControlUnit):
         )
         self._async_add_central_to_device_registry()
         await super().start_central()
+        # The central is available now. Standalone hub entities that key their
+        # availability on it (the backup button) are added before this runs,
+        # have no data point to refresh on and do not poll — so tell them to
+        # re-evaluate. The loom backend in particular reaches its running state
+        # without emitting a state event, so nothing else would.
+        self._async_signal_central_state_changed()
         if self._enable_mqtt:
             self._mqtt_consumer = MQTTConsumer(hass=self._hass, central=self._central, mqtt_prefix=self._mqtt_prefix)
             await self._mqtt_consumer.subscribe()
@@ -657,6 +663,17 @@ class ControlUnit(BaseControlUnit):
         """Run the deferred orphan entity registry cleanup."""
         self._orphan_cleanup_unsub = None
         self._async_cleanup_orphaned_entity_registry_entries()
+
+    @callback
+    def _async_signal_central_state_changed(self) -> None:
+        """Fan out that the central's availability may have changed.
+
+        Standalone hub entities that have no data point of their own — the
+        backup button — key their availability directly on ``central.available``
+        and cannot subscribe to a per-data-point refresh. They connect to this
+        dispatcher signal instead and re-render on it.
+        """
+        async_dispatcher_send(self._hass, signal_central_state_changed(entry_id=self._entry_id))
 
     @callback
     def _cleanup_callback_issues(self) -> None:
@@ -963,6 +980,9 @@ class ControlUnit(BaseControlUnit):
 
     async def _on_central_state_changed(self, *, event: CentralStateChangedEvent) -> None:
         """Handle central state transitions."""
+        # Every transition can flip central.available, so re-notify availability
+        # dependent standalone entities regardless of the specific target state.
+        self._async_signal_central_state_changed()
         if event.new_state == CentralState.RECOVERING:
             await self._on_central_recovering()
         elif event.new_state == CentralState.RUNNING:
@@ -1522,6 +1542,11 @@ def signal_new_data_point(*, entry_id: str, platform: DataPointCategory | str) -
     """Gateway specific event to signal new device."""
     platform_value = platform.value if isinstance(platform, DataPointCategory) else platform
     return f"{DOMAIN}-new-data-point-{entry_id}-{platform_value}"
+
+
+def signal_central_state_changed(*, entry_id: str) -> str:
+    """Gateway specific event to signal that the central's availability changed."""
+    return f"{DOMAIN}-central-state-changed-{entry_id}"
 
 
 async def validate_config_and_get_system_information(

--- a/custom_components/homematicip_local/manifest.json
+++ b/custom_components/homematicip_local/manifest.json
@@ -12,7 +12,7 @@
   "loggers": ["aiohomematic", "aiohomematic_config", "openccu_loom_client"],
   "requirements": [
     "openccu-data==2026.7.2",
-    "openccu-loom-client==2026.8.13",
+    "openccu-loom-client==2026.8.18",
     "aiohomematic-config==2026.8.0",
     "aiohomematic==2026.8.3"
   ],
@@ -22,6 +22,6 @@
       "manufacturerURL": "https://openccu.de"
     }
   ],
-  "version": "2.9.3",
+  "version": "2.9.2",
   "zeroconf": ["_openccu-loom._tcp.local."]
 }

--- a/custom_components/homematicip_local/manifest.json
+++ b/custom_components/homematicip_local/manifest.json
@@ -22,6 +22,6 @@
       "manufacturerURL": "https://openccu.de"
     }
   ],
-  "version": "2.9.2",
+  "version": "2.9.3",
   "zeroconf": ["_openccu-loom._tcp.local."]
 }

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -6,7 +6,7 @@ aiohomematic==2026.8.3
 aiohomematic_config==2026.8.0
 isal==1.8.0
 openccu-data>=2026.7.2
-openccu-loom-client==2026.8.13
+openccu-loom-client==2026.8.18
 mypy<=2.1.0
 prek==0.4.13
 pur==7.4.0

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -1,0 +1,155 @@
+"""Tests for button entities of homematicip_local."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
+
+from aiohomematic.const import CentralState
+from custom_components.homematicip_local.button import HmipLocalCreateBackupButton
+from custom_components.homematicip_local.const import DOMAIN
+from custom_components.homematicip_local.control_unit import BaseControlUnit, ControlUnit, signal_central_state_changed
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.dispatcher import async_dispatcher_send
+
+
+def _make_backup_button(control_unit: object, *, entry_id: str = "test-entry") -> HmipLocalCreateBackupButton:
+    """Create a backup button, bypassing __init__ side effects."""
+    button = object.__new__(HmipLocalCreateBackupButton)
+    button._cu = control_unit
+    button._attr_unique_id = f"{DOMAIN}_CCU_create_backup"
+    button._attr_device_info = {"identifiers": {(DOMAIN, "CCU")}}
+    return button
+
+
+def _make_control_unit(
+    hass: HomeAssistant, *, entry_id: str = "test-entry", available: bool = False, name: str = "CCU"
+) -> ControlUnit:
+    """Create a minimal ControlUnit bound to a real hass, bypassing __init__."""
+    control_unit = object.__new__(ControlUnit)
+    control_unit._hass = hass
+    control_unit._entry_id = entry_id
+    central = MagicMock()
+    central.available = available
+    central.name = name
+    control_unit._central = central
+    return control_unit
+
+
+class TestBackupButtonAvailability:
+    """The backup button's availability tracks the central."""
+
+    def test_available_mirrors_central_available(self) -> None:
+        """Available is True once the central is available."""
+        button = _make_backup_button(MagicMock(central=MagicMock(available=True)))
+        assert button.available is True
+
+    def test_available_mirrors_central_unavailable(self) -> None:
+        """Available is False while the central is not available."""
+        button = _make_backup_button(MagicMock(central=MagicMock(available=False)))
+        assert button.available is False
+
+    async def test_becomes_available_after_central_state_signal(self, hass: HomeAssistant) -> None:
+        """
+        The button flips from unavailable to available on the central-state signal.
+
+        This is the reported bug: the button is added before the central is
+        started (so it reads unavailable at add time) and has no data point or
+        poll to refresh on. It must re-render when the control unit announces the
+        central started. The whole path is exercised here — the production notify
+        method fans out over the real dispatcher into the button's real
+        subscription.
+        """
+        control_unit = _make_control_unit(hass, entry_id="e1", available=False)
+        button = _make_backup_button(control_unit, entry_id="e1")
+        button.hass = hass
+        button.async_write_ha_state = Mock()
+        button.async_on_remove = Mock()
+
+        await button.async_added_to_hass()
+
+        # Added while the central is still stopped.
+        assert button.available is False
+
+        # The central reaches its running state and the control unit announces it.
+        control_unit._central.available = True
+        control_unit._async_signal_central_state_changed()
+        await hass.async_block_till_done()
+
+        button.async_write_ha_state.assert_called()
+        assert button.available is True
+
+    async def test_unsubscribes_on_remove(self, hass: HomeAssistant) -> None:
+        """The dispatcher subscription is torn down when the entity is removed."""
+        control_unit = _make_control_unit(hass, entry_id="e1", available=False)
+        button = _make_backup_button(control_unit, entry_id="e1")
+        button.hass = hass
+        button.async_write_ha_state = Mock()
+
+        unsubscribes: list = []
+        button.async_on_remove = unsubscribes.append
+
+        await button.async_added_to_hass()
+        assert unsubscribes, "async_added_to_hass must register an unsubscribe"
+
+        # Simulate HA removing the entity.
+        for unsubscribe in unsubscribes:
+            unsubscribe()
+
+        button.async_write_ha_state.reset_mock()
+        async_dispatcher_send(hass, signal_central_state_changed(entry_id="e1"))
+        await hass.async_block_till_done()
+
+        button.async_write_ha_state.assert_not_called()
+
+
+class TestCentralStateSignalWiring:
+    """The control unit is the production caller of the central-state signal."""
+
+    def test_notify_dispatches_on_the_signal(self, hass: HomeAssistant) -> None:
+        """_async_signal_central_state_changed sends the entry-scoped signal."""
+        control_unit = _make_control_unit(hass, entry_id="e1")
+        with patch("custom_components.homematicip_local.control_unit.async_dispatcher_send") as send:
+            control_unit._async_signal_central_state_changed()
+        send.assert_called_once_with(hass, signal_central_state_changed(entry_id="e1"))
+
+    async def test_runtime_state_transition_signals(self, hass: HomeAssistant) -> None:
+        """Every central-state transition re-announces the change."""
+        control_unit = _make_control_unit(hass, entry_id="e1")
+        control_unit._instance_name = "X"
+        control_unit._async_signal_central_state_changed = Mock()
+        event = SimpleNamespace(new_state=CentralState.RUNNING)
+
+        with patch.object(ControlUnit, "_on_central_running", new=AsyncMock()):
+            await control_unit._on_central_state_changed(event=event)
+
+        control_unit._async_signal_central_state_changed.assert_called_once()
+
+    def test_signal_is_entry_scoped(self) -> None:
+        """The signal name is scoped to the config entry, so entries don't cross-talk."""
+        assert signal_central_state_changed(entry_id="a") != signal_central_state_changed(entry_id="b")
+
+    async def test_start_central_signals_after_start(self, hass: HomeAssistant) -> None:
+        """
+        start_central announces the central-state change once the central is up.
+
+        Without this the loom backend — which reaches its running state without
+        emitting a state event — would never notify the backup button, leaving it
+        unavailable forever.
+        """
+        control_unit = _make_control_unit(hass, entry_id="e1")
+        control_unit._instance_name = "X"
+        control_unit._subscription_group = MagicMock()
+        control_unit._enable_mqtt = False
+        control_unit._orphan_cleanup_unsub = None
+        control_unit._async_signal_central_state_changed = Mock()
+
+        with (
+            patch.object(ControlUnit, "_cleanup_callback_issues"),
+            patch.object(ControlUnit, "_async_add_central_to_device_registry"),
+            patch.object(BaseControlUnit, "start_central", new=AsyncMock()),
+            patch("custom_components.homematicip_local.control_unit.async_call_later"),
+        ):
+            await control_unit.start_central()
+
+        control_unit._async_signal_central_state_changed.assert_called_once()


### PR DESCRIPTION
## Summary

Fixes #579 — the **Create backup** button stays `unavailable` forever on the openccu-loom backend (Beta).

Home Assistant forwards the `button` platform **before** `start_central()` runs (`__init__.py`: `async_forward_entry_setups` then `control.start_central()`), so `HmipLocalCreateBackupButton.available` (`return self._cu.central.available`) read the central as *stopped* at add time. The entity rides no data point, does not poll and had no subscription, so it never re-evaluated. On the openccu-loom backend the central reaches its running state by setting `_state = Running` directly, **without emitting a state event**, so nothing ever prompted a refresh — the button stayed `unavailable` across restarts and reloads. The native aiohomematic backend was unaffected (its `available` is `all([])` = `True` at that moment).

## Fix

Re-render the button through the same dispatcher mechanism the integration already uses to tell entities something happened (`signal_new_data_point`):

- `control_unit.py`: new entry-scoped `signal_central_state_changed(entry_id)` dispatcher signal, fanned out by `_async_signal_central_state_changed()`. It is called **after `start_central()` completes** (the provable moment the central is available on every backend, including loom's silent transition) and at the top of `_on_central_state_changed()` (so every later transition re-notifies).
- `button.py`: `HmipLocalCreateBackupButton.async_added_to_hass()` subscribes to that signal and calls `async_write_ha_state()` on each change, unsubscribing via `async_on_remove(...)`.

No new `available` semantics — the property still reads `central.available`; the entity simply gets told when to re-read it.

## Tests

New `tests/test_button.py` (8 cases, all green), crossing the seam through the real dispatcher rather than constructing the collaboration:

- button reads `unavailable` at add time and flips to `available` when the **production** `_async_signal_central_state_changed()` fans out over the real dispatcher into the button's real subscription;
- the subscription is torn down on removal;
- `start_central()` fires the signal after the central starts (the boot-path that fixes the bug);
- every `_on_central_state_changed()` transition re-announces it;
- the signal is entry-scoped.

## Notes

- Version bumped `2.9.2 → 2.9.3` (`manifest.json`, `CLAUDE.md`) with a `changelog.md` entry.
- `ruff`, `ruff format` and `mypy` are clean on the changed lines. The pre-commit `mypy` hook and the full-setup `test_init.py` cases fail **locally only** due to a stale venv (aiohomematic `2026.8.2` vs required `2026.8.3`; openccu-loom-client `2026.8.11` vs pinned `2026.8.13`, which lacks `reset_motion_name` used by pre-existing code on `button.py:234`) — both fail identically on `main` and are unrelated to this change. CI installs the pinned versions.