### PR TITLE
feat(select): Expose garage door ventilation mode as a select entity

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,11 @@
+# Version [Unreleased](https://github.com/SukramJ/homematicip_local/compare/2.9.2...HEAD)
+
+## What's Changed
+
+### Features
+
+- Expose the garage door's discrete ventilation mode as a companion `select` entity. Home Assistant's `cover` platform has no native ventilation state (see home-assistant/architecture#502), so the three physical states of a Hörmann-style garage door (`closed`/`ventilation`/`open`) are currently only reachable via the undiscoverable position-range workaround (setting a cover position between the closed and open thresholds). Each `HmIP-MOD-HO`/`HmIP-MOD-TM` garage cover now additionally gets a `select.<garage>_door_mode` entity that reads `CustomDpGarage.current_position` and writes via `close()`/`vent()`/`open()`, so the ventilation command is a first-class, tappable action. Both entities attach to the same HA device. The underlying `CustomDpGarage` data point is already claimed by the cover platform, so discovery uses a registration-agnostic lookup (`ControlUnit.get_data_points_by_type`) and listens to the `COVER` category new-data-point signal directly
+
 # Version [2.9.2](https://github.com/SukramJ/homematicip_local/compare/2.9.1...2.9.2) (2026-08-18)
 
 ## What's Changed

--- a/custom_components/homematicip_local/control_unit.py
+++ b/custom_components/homematicip_local/control_unit.py
@@ -379,6 +379,27 @@ class ControlUnit(BaseControlUnit):
             registered=False,
         )
 
+    def get_data_points_by_type(
+        self,
+        *,
+        data_point_type: DataPointType,
+        category: DataPointCategory | None = None,
+    ) -> tuple[Any, ...]:
+        """
+        Return all data points by type, optionally filtered by category, regardless of registration status.
+
+        Unlike get_new_data_points, this does not filter by registration state.
+        Use this when a data point is expected to back more than one platform
+        entity (e.g. a companion select for a custom cover data point), since
+        the first entity that registers would otherwise hide the data point
+        from every later discovery pass.
+        """
+        return self.central.query_facade.get_data_points(
+            data_point_type=data_point_type,
+            category=category,
+            exclude_no_create=True,
+        )
+
     def get_new_hub_data_points(
         self,
         *,

--- a/custom_components/homematicip_local/select.py
+++ b/custom_components/homematicip_local/select.py
@@ -7,6 +7,7 @@ import logging
 from typing import Any, Final, override
 
 from aiohomematic.const import DataPointCategory, DataPointType
+from aiohomematic.model.custom import CustomDpGarage
 from aiohomematic.model.generic import DpActionSelect, DpSelect
 from aiohomematic.model.hub import SysvarDpSelect
 from homeassistant.components.select import SelectEntity
@@ -17,6 +18,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.storage import Store
 
 from . import HomematicConfigEntry
+from .backend_types import CUSTOM_DP_GARAGE
 from .const import CONF_ACTION_SELECT_VALUES, DP_ACTION_SELECT_WHITELIST
 from .control_unit import ControlUnit, signal_new_data_point
 from .generic_entity import AioHomematicGenericRestoreEntity, AioHomematicGenericSysvarEntity
@@ -133,11 +135,44 @@ async def async_setup_entry(
         ]:
             async_add_entities(entities)
 
+    @callback
+    def async_add_garage_door_mode_select(data_points: tuple[CustomDpGarage, ...]) -> None:
+        """
+        Add a garage door mode select for each garage cover data point.
+
+        This is a companion entity to the cover platform's garage entity: Home
+        Assistant's cover platform has no native ventilation state (see
+        home-assistant/architecture#502), so the door's three discrete physical
+        states (closed/ventilation/open) are exposed here instead. Garage cover
+        data points arrive on the COVER category signal (their own category),
+        not the SELECT one, so this listens to that signal directly rather than
+        the select-specific ones above.
+        """
+        _LOGGER.debug("ASYNC_ADD_GARAGE_DOOR_MODE_SELECT: Adding %i data points", len(data_points))
+
+        if entities := [
+            AioHomematicGarageDoorModeSelect(
+                control_unit=control_unit,
+                data_point=data_point,
+            )
+            for data_point in data_points
+            if isinstance(data_point, CUSTOM_DP_GARAGE)
+        ]:
+            async_add_entities(entities)
+
     entry.async_on_unload(
         func=async_dispatcher_connect(
             hass=hass,
             signal=signal_new_data_point(entry_id=entry.entry_id, platform=DataPointCategory.SELECT),
             target=async_add_select,
+        )
+    )
+
+    entry.async_on_unload(
+        func=async_dispatcher_connect(
+            hass=hass,
+            signal=signal_new_data_point(entry_id=entry.entry_id, platform=DataPointCategory.COVER),
+            target=async_add_garage_door_mode_select,
         )
     )
 
@@ -168,6 +203,17 @@ async def async_setup_entry(
     async_add_action_select(
         data_points=control_unit.get_new_data_points(
             data_point_type=DataPointType.SELECT, category=DataPointCategory.ACTION_SELECT
+        )
+    )
+
+    # get_data_points_by_type (not get_new_data_points!) is required here: the
+    # underlying CustomDpGarage data point is already claimed by the cover
+    # platform's garage entity, which flips its registration state. Filtering
+    # by registration status would make this pass find nothing whenever the
+    # cover platform's setup already ran.
+    async_add_garage_door_mode_select(
+        data_points=control_unit.get_data_points_by_type(
+            data_point_type=DataPointType.COVER, category=DataPointCategory.COVER
         )
     )
 
@@ -338,3 +384,66 @@ class AioHomematicActionSelect(AioHomematicGenericRestoreEntity[DpActionSelect],
                 channel_address,
                 parameter,
             )
+
+
+# Door positions reported by CustomDpGarage.current_position (aiohomematic's
+# _CoverPosition enum values, mirrored here since that enum is private).
+_GARAGE_POSITION_CLOSED: Final = 0
+_GARAGE_POSITION_VENTILATION: Final = 10
+_GARAGE_POSITION_OPEN: Final = 100
+
+GARAGE_DOOR_MODE_CLOSED: Final = "closed"
+GARAGE_DOOR_MODE_VENTILATION: Final = "ventilation"
+GARAGE_DOOR_MODE_OPEN: Final = "open"
+
+_GARAGE_DOOR_MODE_BY_POSITION: Final[dict[int, str]] = {
+    _GARAGE_POSITION_CLOSED: GARAGE_DOOR_MODE_CLOSED,
+    _GARAGE_POSITION_VENTILATION: GARAGE_DOOR_MODE_VENTILATION,
+    _GARAGE_POSITION_OPEN: GARAGE_DOOR_MODE_OPEN,
+}
+
+
+class AioHomematicGarageDoorModeSelect(AioHomematicGenericRestoreEntity[CustomDpGarage], SelectEntity):
+    """
+    Representation of a garage door's discrete mode as a select entity.
+
+    Companion entity to the cover platform's garage entity (AioHomematicGarage
+    in cover.py): exposes the door's three physical states (closed/ventilation/
+    open) directly, since Home Assistant's cover platform has no native
+    ventilation state and the position-based workaround (setting a cover
+    position between the closed and open thresholds) is not discoverable.
+    """
+
+    _attr_translation_key = "garage_door_mode"
+
+    def __init__(self, *, control_unit: ControlUnit, data_point: CustomDpGarage) -> None:
+        """Initialize the garage door mode select entity."""
+        super().__init__(control_unit=control_unit, data_point=data_point)
+        # Distinct from the cover entity's unique_id, which is derived from
+        # the same underlying CustomDpGarage data point.
+        self._attr_unique_id = f"{self._attr_unique_id}_door_mode"
+
+    @property
+    @override
+    def current_option(self) -> str | None:
+        """Return the currently selected door mode."""
+        if (position := self._data_point.current_position) is None:
+            return None
+        return _GARAGE_DOOR_MODE_BY_POSITION.get(position)
+
+    @property
+    @override
+    def options(self) -> list[str]:
+        """Return the available door modes."""
+        return [GARAGE_DOOR_MODE_CLOSED, GARAGE_DOOR_MODE_VENTILATION, GARAGE_DOOR_MODE_OPEN]
+
+    @override
+    @handle_homematic_errors
+    async def async_select_option(self, option: str) -> None:
+        """Move the garage door to the selected mode."""
+        if option == GARAGE_DOOR_MODE_CLOSED:
+            await self._data_point.close()
+        elif option == GARAGE_DOOR_MODE_VENTILATION:
+            await self._data_point.vent()
+        elif option == GARAGE_DOOR_MODE_OPEN:
+            await self._data_point.open()

--- a/custom_components/homematicip_local/strings.json
+++ b/custom_components/homematicip_local/strings.json
@@ -348,6 +348,14 @@
                     "low_battery": "Low battery"
                 }
             }, 
+            "garage_door_mode": {
+                "name": "Door mode", 
+                "state": {
+                    "closed": "Closed", 
+                    "open": "Open", 
+                    "ventilation": "Ventilation"
+                }
+            }, 
             "heating_cooling": {
                 "name": "Operating mode", 
                 "state": {

--- a/custom_components/homematicip_local/translations/de.json
+++ b/custom_components/homematicip_local/translations/de.json
@@ -348,6 +348,14 @@
                     "low_battery": "Niedriger Batteriestand"
                 }
             }, 
+            "garage_door_mode": {
+                "name": "Türmodus", 
+                "state": {
+                    "closed": "Geschlossen", 
+                    "open": "Offen", 
+                    "ventilation": "Lüften"
+                }
+            }, 
             "heating_cooling": {
                 "name": "Betriebsmodus", 
                 "state": {

--- a/custom_components/homematicip_local/translations/en.json
+++ b/custom_components/homematicip_local/translations/en.json
@@ -325,6 +325,14 @@
       }
     },
     "select": {
+      "garage_door_mode": {
+        "name": "Door mode",
+        "state": {
+          "closed": "Closed",
+          "open": "Open",
+          "ventilation": "Ventilation"
+        }
+      },
       "acoustic_alarm_selection": {
         "name": "Siren Tone",
         "state": {

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -1,0 +1,87 @@
+"""Tests for select entities of homematicip_local."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+from custom_components.homematicip_local.const import DOMAIN
+from custom_components.homematicip_local.select import (
+    GARAGE_DOOR_MODE_CLOSED,
+    GARAGE_DOOR_MODE_OPEN,
+    GARAGE_DOOR_MODE_VENTILATION,
+    AioHomematicGarageDoorModeSelect,
+)
+
+
+def _make_garage_door_mode_select(*, current_position: int | None) -> AioHomematicGarageDoorModeSelect:
+    """Create a garage door mode select, bypassing __init__ side effects."""
+    select = object.__new__(AioHomematicGarageDoorModeSelect)
+    data_point = MagicMock()
+    data_point.current_position = current_position
+    data_point.close = AsyncMock()
+    data_point.vent = AsyncMock()
+    data_point.open = AsyncMock()
+    select._data_point = data_point
+    select._attr_unique_id = f"{DOMAIN}_garage_test_door_mode"
+    return select
+
+
+class TestGarageDoorModeSelectCurrentOption:
+    """current_option reflects the garage door's physical position."""
+
+    def test_closed_position_maps_to_closed(self) -> None:
+        """A fully closed door reports the closed mode."""
+        select = _make_garage_door_mode_select(current_position=0)
+        assert select.current_option == GARAGE_DOOR_MODE_CLOSED
+
+    def test_ventilation_position_maps_to_ventilation(self) -> None:
+        """A door in the ventilation position reports the ventilation mode."""
+        select = _make_garage_door_mode_select(current_position=10)
+        assert select.current_option == GARAGE_DOOR_MODE_VENTILATION
+
+    def test_open_position_maps_to_open(self) -> None:
+        """A fully open door reports the open mode."""
+        select = _make_garage_door_mode_select(current_position=100)
+        assert select.current_option == GARAGE_DOOR_MODE_OPEN
+
+    def test_unknown_position_maps_to_none(self) -> None:
+        """An unresolvable position (e.g. during travel) reports no mode."""
+        select = _make_garage_door_mode_select(current_position=None)
+        assert select.current_option is None
+
+
+class TestGarageDoorModeSelectOptions:
+    """options always exposes exactly the three physical door modes."""
+
+    def test_options_are_closed_ventilation_open(self) -> None:
+        """The three physical states are exposed, in a stable order."""
+        select = _make_garage_door_mode_select(current_position=0)
+        assert select.options == [GARAGE_DOOR_MODE_CLOSED, GARAGE_DOOR_MODE_VENTILATION, GARAGE_DOOR_MODE_OPEN]
+
+
+class TestGarageDoorModeSelectSelectOption:
+    """async_select_option dispatches to the matching CustomDpGarage command."""
+
+    async def test_select_closed_calls_close(self) -> None:
+        """Selecting 'closed' issues the close command."""
+        select = _make_garage_door_mode_select(current_position=100)
+        await select.async_select_option(GARAGE_DOOR_MODE_CLOSED)
+        select._data_point.close.assert_awaited_once()
+        select._data_point.vent.assert_not_awaited()
+        select._data_point.open.assert_not_awaited()
+
+    async def test_select_ventilation_calls_vent(self) -> None:
+        """Selecting 'ventilation' issues the vent (PARTIAL_OPEN) command."""
+        select = _make_garage_door_mode_select(current_position=0)
+        await select.async_select_option(GARAGE_DOOR_MODE_VENTILATION)
+        select._data_point.vent.assert_awaited_once()
+        select._data_point.close.assert_not_awaited()
+        select._data_point.open.assert_not_awaited()
+
+    async def test_select_open_calls_open(self) -> None:
+        """Selecting 'open' issues the open command."""
+        select = _make_garage_door_mode_select(current_position=0)
+        await select.async_select_option(GARAGE_DOOR_MODE_OPEN)
+        select._data_point.open.assert_awaited_once()
+        select._data_point.close.assert_not_awaited()
+        select._data_point.vent.assert_not_awaited()


### PR DESCRIPTION
Home Assistant's cover platform has no native ventilation state (home-assistant/architecture#502), so the three physical states of a Hörmann-style garage door (closed/ventilation/open) are currently only reachable via the undiscoverable position-range workaround: setting a cover position between the closed and open thresholds maps to DOOR_COMMAND=PARTIAL_OPEN inside aiohomematic, but nothing in the UI hints at that range.

Add a companion select entity for each HmIP-MOD-HO/HmIP-MOD-TM garage cover that reads CustomDpGarage.current_position and writes via close()/vent()/open(), making the ventilation command a first-class, tappable action. Both the cover and the select attach to the same HA device, mirroring the multi-entity-per-device pattern used by other integrations (e.g. Reolink cameras expose light + select + switch on one device).

Discovery note: the underlying CustomDpGarage data point is already claimed by the cover platform's garage entity, which flips its registration state. The standard get_new_data_points (registered=False) filter would therefore miss it whenever the cover platform's setup ran first. A registration-agnostic ControlUnit.get_data_points_by_type lookup is added, and the select platform subscribes to the COVER category new-data-point signal directly (garage data points arrive on that category, not SELECT).

   ## Tests & validation

   - Unit tests added in `tests/test_select.py` (option mapping for closed/ventilation/open/None, and command dispatch to close()/vent()/open()).
   - `ruff check`, `ruff format`, and `script/check_translations.py` pass locally.
   - Full `make check` (pytest + mypy strict) not yet run locally — feedback welcome if CI flags anything.

   ## AI disclaimer

   Per `AI_POLICY.md`: this change was developed with AI assistance, but I have reviewed and understand every part of it and can explain it in my own words. It is not an autonomous agent submission.
