### PR TITLE
fix(loom): device classes for the daemon-connection and Security & Safety sensors

### DIFF
--- a/custom_components/homematicip_local/entity_helpers/descriptions/hub.py
+++ b/custom_components/homematicip_local/entity_helpers/descriptions/hub.py
@@ -93,6 +93,26 @@ HUB_RULES: list[EntityDescriptionRule] = [
             device_class=BinarySensorDeviceClass.CONNECTIVITY,
         ),
     ),
+    # Hub binary sensor - daemon reachability (openccu-loom backend only).
+    #
+    # It answers the same question as the per-interface connectivity
+    # sensors one layer up — is the thing we talk to there — so it carries
+    # the same device class. Without it the entity renders as a bare
+    # on/off, and Home Assistant cannot tell that "off" is the bad state.
+    #
+    # It needs its own rule because the connectivity rule above matches on
+    # the "Connectivity" name prefix, and this singleton is named
+    # "daemon_connection": "connectivity" is not a substring of
+    # "daemon_connection", so it was falling through to no description at
+    # all.
+    EntityDescriptionRule(
+        category=DataPointCategory.HUB_BINARY_SENSOR,
+        var_name_contains="daemon_connection",
+        description=HmBinarySensorEntityDescription(
+            key="DAEMON_CONNECTION",
+            device_class=BinarySensorDeviceClass.CONNECTIVITY,
+        ),
+    ),
     # Hub sensors - Energy counter (system variables)
     EntityDescriptionRule(
         category=DataPointCategory.HUB_SENSOR,

--- a/custom_components/homematicip_local/entity_helpers/descriptions/hub.py
+++ b/custom_components/homematicip_local/entity_helpers/descriptions/hub.py
@@ -113,6 +113,91 @@ HUB_RULES: list[EntityDescriptionRule] = [
             device_class=BinarySensorDeviceClass.CONNECTIVITY,
         ),
     ),
+    # Hub binary sensors - Security & Safety hazard classes (openccu-loom
+    # backend). One sensor per class the daemon folds its sources into.
+    #
+    # Each carries the device class Home Assistant already knows for that
+    # hazard, so the entity gets the right icon, the right on/off wording
+    # and the semantics voice assistants and automation blueprints match
+    # on. Without one they are bare on/off toggles, and "on" — which here
+    # means a detector has fired — reads as the good state.
+    #
+    # Two have no exact counterpart: HA knows neither "intrusion" nor
+    # "panic". SAFETY is the closest — it renders as Safe/Unsafe, which is
+    # the right polarity for both — and is chosen over leaving them blank
+    # because a wrong-but-close icon still beats no state semantics at all.
+    EntityDescriptionRule(
+        category=DataPointCategory.HUB_BINARY_SENSOR,
+        var_name_contains="security_smoke",
+        description=HmBinarySensorEntityDescription(
+            key="SECURITY_SMOKE",
+            device_class=BinarySensorDeviceClass.SMOKE,
+        ),
+    ),
+    EntityDescriptionRule(
+        category=DataPointCategory.HUB_BINARY_SENSOR,
+        var_name_contains="security_water",
+        description=HmBinarySensorEntityDescription(
+            key="SECURITY_WATER",
+            device_class=BinarySensorDeviceClass.MOISTURE,
+        ),
+    ),
+    EntityDescriptionRule(
+        category=DataPointCategory.HUB_BINARY_SENSOR,
+        var_name_contains="security_gas",
+        description=HmBinarySensorEntityDescription(
+            key="SECURITY_GAS",
+            device_class=BinarySensorDeviceClass.GAS,
+        ),
+    ),
+    EntityDescriptionRule(
+        category=DataPointCategory.HUB_BINARY_SENSOR,
+        var_name_contains="security_co",
+        description=HmBinarySensorEntityDescription(
+            key="SECURITY_CO",
+            device_class=BinarySensorDeviceClass.CO,
+        ),
+    ),
+    EntityDescriptionRule(
+        category=DataPointCategory.HUB_BINARY_SENSOR,
+        var_name_contains="security_tamper",
+        description=HmBinarySensorEntityDescription(
+            key="SECURITY_TAMPER",
+            device_class=BinarySensorDeviceClass.TAMPER,
+        ),
+    ),
+    EntityDescriptionRule(
+        category=DataPointCategory.HUB_BINARY_SENSOR,
+        var_name_contains="security_battery",
+        description=HmBinarySensorEntityDescription(
+            key="SECURITY_BATTERY",
+            device_class=BinarySensorDeviceClass.BATTERY,
+        ),
+    ),
+    EntityDescriptionRule(
+        category=DataPointCategory.HUB_BINARY_SENSOR,
+        var_name_contains="security_technical",
+        description=HmBinarySensorEntityDescription(
+            key="SECURITY_TECHNICAL",
+            device_class=BinarySensorDeviceClass.PROBLEM,
+        ),
+    ),
+    EntityDescriptionRule(
+        category=DataPointCategory.HUB_BINARY_SENSOR,
+        var_name_contains="security_intrusion",
+        description=HmBinarySensorEntityDescription(
+            key="SECURITY_INTRUSION",
+            device_class=BinarySensorDeviceClass.SAFETY,
+        ),
+    ),
+    EntityDescriptionRule(
+        category=DataPointCategory.HUB_BINARY_SENSOR,
+        var_name_contains="security_panic",
+        description=HmBinarySensorEntityDescription(
+            key="SECURITY_PANIC",
+            device_class=BinarySensorDeviceClass.SAFETY,
+        ),
+    ),
     # Hub sensors - Energy counter (system variables)
     EntityDescriptionRule(
         category=DataPointCategory.HUB_SENSOR,

--- a/tests/test_entity_helper.py
+++ b/tests/test_entity_helper.py
@@ -101,6 +101,37 @@ class TestEntityHelper:
         assert description.key == "CONNECTIVITY_SENSOR"
         assert description.device_class == BinarySensorDeviceClass.CONNECTIVITY
 
+    @pytest.mark.parametrize(
+        ("security_class", "device_class"),
+        [
+            ("smoke", BinarySensorDeviceClass.SMOKE),
+            ("water", BinarySensorDeviceClass.MOISTURE),
+            ("gas", BinarySensorDeviceClass.GAS),
+            ("co", BinarySensorDeviceClass.CO),
+            ("tamper", BinarySensorDeviceClass.TAMPER),
+            ("battery", BinarySensorDeviceClass.BATTERY),
+            ("technical", BinarySensorDeviceClass.PROBLEM),
+            ("intrusion", BinarySensorDeviceClass.SAFETY),
+            ("panic", BinarySensorDeviceClass.SAFETY),
+        ],
+    )
+    def test_registry_find_security_class(self, security_class: str, device_class: BinarySensorDeviceClass) -> None:
+        """
+        Each Security & Safety hazard class carries its own device class.
+
+        Without one the sensor is a bare on/off, and "on" — a detector has
+        fired — reads as the good state. The table is spelled out rather
+        than derived so that changing a mapping has to change a test: a
+        loop over the rules would agree with whatever the rules say.
+        """
+        description = REGISTRY.find(
+            category=DataPointCategory.HUB_BINARY_SENSOR,
+            var_name=f"security_{security_class}",
+        )
+
+        assert description is not None
+        assert description.device_class == device_class
+
     def test_registry_find_sensor(self) -> None:
         """Test finding a sensor description."""
         description = REGISTRY.find(
@@ -147,3 +178,22 @@ class TestEntityHelper:
         assert stats["SENSOR"] > 50
         assert stats["BINARY_SENSOR"] > 10
         assert stats["BUTTON"] > 0
+
+    def test_registry_security_classes_do_not_shadow_connectivity(self) -> None:
+        """
+        The security rules must not swallow the connectivity sensors.
+
+        Both families are HUB_BINARY_SENSOR and matched by substring, and
+        the first matching rule wins — so a rule matched on a shorter
+        fragment would quietly take entities it was never meant to.
+        """
+        for var_name, expected in (
+            ("daemon_connection", "DAEMON_CONNECTION"),
+            ("Connectivity HmIP-RF", "CONNECTIVITY_SENSOR"),
+        ):
+            description = REGISTRY.find(
+                category=DataPointCategory.HUB_BINARY_SENSOR,
+                var_name=var_name,
+            )
+            assert description is not None
+            assert description.key == expected

--- a/tests/test_entity_helper.py
+++ b/tests/test_entity_helper.py
@@ -6,6 +6,7 @@ import pytest
 
 from aiohomematic.const import DataPointCategory
 from custom_components.homematicip_local.entity_helpers import REGISTRY
+from homeassistant.components.binary_sensor import BinarySensorDeviceClass
 from homeassistant.components.event import EventDeviceClass
 
 
@@ -44,6 +45,28 @@ class TestEntityHelper:
         assert description is not None
         assert description.key == "BLIND"
 
+    def test_registry_find_daemon_connection(self) -> None:
+        """
+        The openccu-loom daemon-reachability sensor carries CONNECTIVITY.
+
+        It answers the same question as the per-interface connectivity
+        sensors one layer up, so it needs the same device class — without
+        one Home Assistant renders a bare on/off and cannot tell that
+        "off" is the bad state.
+
+        It needs a rule of its own because the interface rule matches the
+        ``Connectivity`` name prefix and this singleton is named
+        ``daemon_connection``; the one is not a substring of the other.
+        """
+        description = REGISTRY.find(
+            category=DataPointCategory.HUB_BINARY_SENSOR,
+            var_name="daemon_connection",
+        )
+
+        assert description is not None
+        assert description.key == "DAEMON_CONNECTION"
+        assert description.device_class == BinarySensorDeviceClass.CONNECTIVITY
+
     @pytest.mark.parametrize("device_model", ["HmIP-DBB", "HmIP-DSD-PCB"])
     def test_registry_find_doorbell_event(self, device_model: str) -> None:
         """Doorbell devices expose their event group with the doorbell device class."""
@@ -66,6 +89,17 @@ class TestEntityHelper:
         assert description is not None
         assert description.key == "event_default"
         assert description.device_class == EventDeviceClass.BUTTON
+
+    def test_registry_find_interface_connectivity(self) -> None:
+        """The per-interface sensor keeps its own rule — the two must not collapse."""
+        description = REGISTRY.find(
+            category=DataPointCategory.HUB_BINARY_SENSOR,
+            var_name="Connectivity HmIP-RF",
+        )
+
+        assert description is not None
+        assert description.key == "CONNECTIVITY_SENSOR"
+        assert description.device_class == BinarySensorDeviceClass.CONNECTIVITY
 
     def test_registry_find_sensor(self) -> None:
         """Test finding a sensor description."""


### PR DESCRIPTION
Two openccu-loom-backend entity families were reaching Home Assistant with no
entity description at all, so they rendered as bare on/off toggles.

## Daemon connection

The daemon-reachability binary sensor answers the same question as the
per-interface connectivity sensors one layer up — *is the thing we talk to
there* — so it now carries the same `connectivity` device class. Without one HA
had no way to know that **off** is the bad state, and the entity showed neither
the connectivity icon nor the Connected/Disconnected wording every sibling
uses.

It needed a rule of its own: the existing rule matches the `Connectivity` name
prefix, and this singleton is named `daemon_connection`. One is not a substring
of the other, so it matched nothing.

## Security & Safety hazard sensors

Nine per-hazard binary sensors, likewise undescribed — and for a detector that
is the wrong way round: **on** means one has fired, and without a device class
HA renders it as the plain, unremarkable state.

| class | device_class |
|---|---|
| smoke | `smoke` |
| water | `moisture` |
| gas | `gas` |
| co | `carbon_monoxide` |
| tamper | `tamper` |
| battery | `battery` |
| technical | `problem` |
| intrusion | `safety` |
| panic | `safety` |

Seven map exactly. HA knows neither *intrusion* nor *panic*; both get `safety`,
which renders as Safe/Unsafe — the right polarity for each, and a
close-but-imperfect class still beats no state semantics. The choice is written
at the rules rather than left to be inferred.

## Two entities deliberately left alone

Measuring them corrected the assumption I started from, so they are recorded
rather than changed:

- **`security_faults`** is a `HUB_SENSOR` carrying an **INTEGER count** of open
  faults, not a binary sensor. `BinarySensorDeviceClass.PROBLEM` would have been
  simply wrong, and HA has no sensor class for "number of faults".
- **`security_severity`** already resolves to `SensorDeviceClass.ENUM`: the
  sensor platform sets that automatically for any data point exposing `values`,
  and the severity singleton exposes its five (`ok`/`info`/`warning`/`alarm`/
  `critical`). A rule would be redundant.

The two `update` entities are also not a gap — `update.py` sets
`UpdateDeviceClass.FIRMWARE` directly.

## Tests

The hazard mapping is spelled out as a table rather than derived from the
rules: a loop over the rules would agree with whatever the rules say and could
never disagree with a wrong mapping.

The shadowing test is the one that earns its place. Both families are
`HUB_BINARY_SENSOR`, matched by substring, **first match wins** — so a rule
matched on too short a fragment quietly takes entities it was never meant to.
Shortening one security matcher to `"n"` reddens four cases including the
connectivity pair, which is exactly the failure it guards. Flipping the smoke
mapping to `GAS` reddens only its own case.

## Verification

`pytest` (917 passed, 8 skipped), `ruff check`, `mypy` and the full pre-commit
hook set are green.
