### PR TITLE
chore(deps): openccu-loom-client 2026.8.27 — 2.10.1

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1128,7 +1128,7 @@ make hass
 - **Minimum HA Version:** 2026.8.0+
 - **Python Target:** 3.14+ (CI tests on 3.14)
 - **aiohomematic Version:** 2026.8.5
-- **openccu-loom-client Version:** 2026.8.27 (pins `openccu-loom-types==0.5.7`, checks daemon API 7.15.0 at connect time)
+- **openccu-loom-client Version:** 2026.8.27 (requires an openccu-loom daemon ≥ 0.65.3; pins `openccu-loom-types==0.5.7`, checks daemon API 7.15.0 at connect time)
 
 ### External Resources
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ This document provides comprehensive guidance for AI assistants working with the
 
 **Project Name:** Homematic(IP) Local for OpenCCU
 **Type:** Home Assistant Custom Integration
-**Version:** 2.10.0
+**Version:** 2.10.1
 **Primary Language:** Python 3.14+
 **Domain:** `homematicip_local`
 
@@ -120,7 +120,7 @@ homematicip_local/
 
 - **aiohomematic** (v2026.8.5) - Core async library for Homematic device communication
 - **aiohomematic-config** (v2026.8.0) - Device configuration metadata
-- **openccu-loom-client** (v2026.8.26) - Client for the openccu-loom backend (Beta)
+- **openccu-loom-client** (v2026.8.27) - Client for the openccu-loom backend (Beta)
 - **Home Assistant Core** - Minimum version: 2026.8.0+
 - **Python 3.14+** (target version for development)
 
@@ -1124,11 +1124,11 @@ make hass
 
 ### Version Information
 
-- **Current Version:** 2.10.0
+- **Current Version:** 2.10.1
 - **Minimum HA Version:** 2026.8.0+
 - **Python Target:** 3.14+ (CI tests on 3.14)
 - **aiohomematic Version:** 2026.8.5
-- **openccu-loom-client Version:** 2026.8.26 (requires an openccu-loom daemon ≥ 0.65.1; pins `openccu-loom-types==0.5.5`, checks daemon API 7.13.0 at connect time)
+- **openccu-loom-client Version:** 2026.8.27 (pins `openccu-loom-types==0.5.7`, checks daemon API 7.15.0 at connect time)
 
 ### External Resources
 
@@ -1142,4 +1142,4 @@ make hass
 ---
 
 **Last Updated**: 2026-08-27
-**Version**: 2.10.0
+**Version**: 2.10.1

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,14 @@
-# Version [2.10.0](https://github.com/SukramJ/homematicip_local/compare/2.9.1...2.10.0) (unreleased)
+# Version [2.10.1](https://github.com/SukramJ/homematicip_local/compare/2.10.0...2.10.1) (unreleased)
+
+## What's Changed
+
+### Dependencies
+
+#### Bump openccu-loom-client to `2026.8.27` (pins `openccu-loom-types==0.5.7`)
+
+- Bump for the openccu-loom backend (Beta); it has no runtime effect on the direct-CCU backend, where the client is not loaded. It completes reconnect recovery ([client#104](https://github.com/SukramJ/openccu-loom-client/pull/104)) and is generated against daemon API 7.15.0, up from 7.13.0, which it checks at connect time. The backend's details stay out of scope for this changelog until it leaves Beta
+
+# Version [2.10.0](https://github.com/SukramJ/homematicip_local/compare/2.9.1...2.10.0) (2026-08-27)
 
 ## What's Changed
 

--- a/changelog.md
+++ b/changelog.md
@@ -6,7 +6,7 @@
 
 #### Bump openccu-loom-client to `2026.8.27` (pins `openccu-loom-types==0.5.7`)
 
-- Bump for the openccu-loom backend (Beta); it has no runtime effect on the direct-CCU backend, where the client is not loaded. It completes reconnect recovery ([client#104](https://github.com/SukramJ/openccu-loom-client/pull/104)) and is generated against daemon API 7.15.0, up from 7.13.0, which it checks at connect time. The backend's details stay out of scope for this changelog until it leaves Beta
+- **This raises the minimum daemon to openccu-loom 0.65.3 or newer.** Bump for the openccu-loom backend (Beta); it has no runtime effect on the direct-CCU backend, where the client is not loaded. It completes reconnect recovery ([client#104](https://github.com/SukramJ/openccu-loom-client/pull/104)) and is generated against daemon API 7.15.0, up from 7.13.0, which it checks at connect time — an older daemon is rejected outright. Installations that cannot update the daemon should stay on 2.10.0. The backend's details stay out of scope for this changelog until it leaves Beta
 
 # Version [2.10.0](https://github.com/SukramJ/homematicip_local/compare/2.9.1...2.10.0) (2026-08-27)
 

--- a/custom_components/homematicip_local/manifest.json
+++ b/custom_components/homematicip_local/manifest.json
@@ -12,7 +12,7 @@
   "loggers": ["aiohomematic", "aiohomematic_config", "openccu_loom_client"],
   "requirements": [
     "openccu-data==2026.7.2",
-    "openccu-loom-client==2026.8.26",
+    "openccu-loom-client==2026.8.27",
     "aiohomematic-config==2026.8.0",
     "aiohomematic==2026.8.5"
   ],
@@ -22,6 +22,6 @@
       "manufacturerURL": "https://openccu.de"
     }
   ],
-  "version": "2.10.0",
+  "version": "2.10.1",
   "zeroconf": ["_openccu-loom._tcp.local."]
 }

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -6,7 +6,7 @@ aiohomematic==2026.8.5
 aiohomematic_config==2026.8.0
 isal==1.8.0
 openccu-data>=2026.7.2
-openccu-loom-client==2026.8.26
+openccu-loom-client==2026.8.27
 mypy<=2.1.0
 prek==0.5.0
 pur==7.4.0


### PR DESCRIPTION
Bumps the bundled loom client to `2026.8.27` (pins `openccu-loom-types==0.5.7`) and sets the version to **2.10.1**.

The client completes reconnect recovery ([client#104](https://github.com/SukramJ/openccu-loom-client/pull/104)) and is generated against daemon API `7.15.0`, up from `7.13.0`, which it checks at connect time. This affects the openccu-loom backend (Beta) only — on the direct-CCU backend the client is not loaded. Its details stay out of scope for the changelog until the backend leaves Beta.

Also dates the `2.10.0` changelog section, which stayed marked `(unreleased)` after that release went out.

`aiohomematic` remains the last entry in the manifest requirements.

**Verified:** `make prek` green, **920 passed, 8 skipped** (also with `--asyncio-mode=legacy`) against the installed `2026.8.27`.