### PR TITLE
fix(generic_entity): never make a device its own via device

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
         types_or: [python]
         files: ^(custom_components/homematicip_local|tests)/.+\.py$
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.16.4
+    rev: v0.16.5
     hooks:
       - id: ruff
         args:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,20 +119,20 @@ homematicip_local/
 ### Runtime Dependencies
 
 - **aiohomematic** (v2026.8.5) - Core async library for Homematic device communication
-- **aiohomematic-config** (v2026.8.0) - Device configuration metadata
-- **openccu-loom-client** (v2026.8.27) - Client for the openccu-loom backend (Beta)
+- **aiohomematic-config** (v2026.8.1) - Device configuration metadata
+- **openccu-loom-client** (v2026.8.29) - Client for the openccu-loom backend (Beta)
 - **Home Assistant Core** - Minimum version: 2026.8.0+
 - **Python 3.14+** (target version for development)
 
 ### Development Dependencies
 
-- **pytest-homeassistant-custom-component-framework** (1.0.46) - HA test framework
+- **pytest-homeassistant-custom-component-framework** (1.0.48) - HA test framework
 - **mypy** (2.1.0) - Static type checker (strict mode)
 - **pylint** (4.0.7) - Code linting
-- **ruff** (0.16.4) - Fast Python linter and formatter
-- **prek** (0.4.14) - Git hooks manager (Rust-based pre-commit alternative)
+- **ruff** (0.16.5) - Fast Python linter and formatter
+- **prek** (0.5.0) - Git hooks manager (Rust-based pre-commit alternative)
 - **aiohomematic-test-support** (2026.8.5) - Mock test data
-- **async-upnp-client** (0.48.0) - UPnP discovery
+- **async-upnp-client** (0.48.1) - UPnP discovery
 - **uv** - Fast Python package installer (preferred over pip)
 
 ---
@@ -1128,7 +1128,7 @@ make hass
 - **Minimum HA Version:** 2026.8.0+
 - **Python Target:** 3.14+ (CI tests on 3.14)
 - **aiohomematic Version:** 2026.8.5
-- **openccu-loom-client Version:** 2026.8.27 (requires an openccu-loom daemon ≥ 0.65.3; pins `openccu-loom-types==0.5.7`, checks daemon API 7.15.0 at connect time)
+- **openccu-loom-client Version:** 2026.8.29 (pins `openccu-loom-types==0.5.9`, checks daemon API 7.21.0 at connect time)
 
 ### External Resources
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1128,7 +1128,7 @@ make hass
 - **Minimum HA Version:** 2026.8.0+
 - **Python Target:** 3.14+ (CI tests on 3.14)
 - **aiohomematic Version:** 2026.8.5
-- **openccu-loom-client Version:** 2026.8.29 (pins `openccu-loom-types==0.5.9`, checks daemon API 7.21.0 at connect time)
+- **openccu-loom-client Version:** 2026.8.29 (requires an openccu-loom daemon ≥ 0.66.1; pins `openccu-loom-types==0.5.9`, checks daemon API 7.21.0 at connect time)
 
 ### External Resources
 

--- a/changelog.md
+++ b/changelog.md
@@ -8,9 +8,13 @@
 
 ### Dependencies
 
-#### Bump openccu-loom-client to `2026.8.27` (pins `openccu-loom-types==0.5.7`)
+#### Bump openccu-loom-client to `2026.8.29` (pins `openccu-loom-types==0.5.9`)
 
-- **This raises the minimum daemon to openccu-loom 0.65.3 or newer.** Bump for the openccu-loom backend (Beta); it has no runtime effect on the direct-CCU backend, where the client is not loaded. It completes reconnect recovery ([client#104](https://github.com/SukramJ/openccu-loom-client/pull/104)) and is generated against daemon API 7.15.0, up from 7.13.0, which it checks at connect time — an older daemon is rejected outright. Installations that cannot update the daemon should stay on 2.10.0. The backend's details stay out of scope for this changelog until it leaves Beta
+- **This raises the minimum daemon: the client is generated against daemon API 7.21.0, up from 7.13.0, and checks that version at connect time — an older daemon is rejected outright.** Bump for the openccu-loom backend (Beta); it has no runtime effect on the direct-CCU backend, where the client is not loaded. It completes reconnect recovery, adopts the onboarding release state and fixes a double-scaled `hs_color`. Installations that cannot update the daemon should stay on 2.10.0. The backend's details stay out of scope for this changelog until it leaves Beta
+
+#### Bump aiohomematic-config to [2026.8.1](https://github.com/SukramJ/aiohomematic-config/compare/2026.8.0...2026.8.1)
+
+- Packaging and tooling only, no behaviour change: the package raises its own `aiohomematic` requirement to `>=2026.8.5`, is marked production/stable, and updates its development dependencies
 
 # Version [2.10.0](https://github.com/SukramJ/homematicip_local/compare/2.9.1...2.10.0) (2026-08-27)
 

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,10 @@
 
 ## What's Changed
 
+### Integration
+
+- **Fix: a sub-device channel without a group master could make its device its own via device.** With sub devices enabled, the via device was moved up to the Homematic device as soon as a channel reported itself as part of a multi-channel group — before the group master, which supplies the sub-device identifier, was resolved. Without a master the identifier stayed on the device, so device and via device were the same. HA used to ignore such a self-reference with a log line; since 2026.9 it raises a `HomeAssistantError` that no platform catches, which would take down the whole platform setup ([device registry follow-up changes](https://developers.home-assistant.io/blog/2026/08/24/device-registry-follow-up-changes/)). The split is now conditional on the group master, so a channel without one simply stays on its device, below the central
+
 ### Dependencies
 
 #### Bump openccu-loom-client to `2026.8.27` (pins `openccu-loom-types==0.5.7`)

--- a/changelog.md
+++ b/changelog.md
@@ -10,7 +10,7 @@
 
 #### Bump openccu-loom-client to `2026.8.29` (pins `openccu-loom-types==0.5.9`)
 
-- **This raises the minimum daemon: the client is generated against daemon API 7.21.0, up from 7.13.0, and checks that version at connect time — an older daemon is rejected outright.** Bump for the openccu-loom backend (Beta); it has no runtime effect on the direct-CCU backend, where the client is not loaded. It completes reconnect recovery, adopts the onboarding release state and fixes a double-scaled `hs_color`. Installations that cannot update the daemon should stay on 2.10.0. The backend's details stay out of scope for this changelog until it leaves Beta
+- **This raises the minimum daemon to openccu-loom 0.66.1 or newer.** Bump for the openccu-loom backend (Beta); it has no runtime effect on the direct-CCU backend, where the client is not loaded. It completes reconnect recovery, adopts the onboarding release state and fixes a double-scaled `hs_color`; it is generated against daemon API 7.21.0, up from 7.13.0, which it checks at connect time — an older daemon is rejected outright. Installations that cannot update the daemon should stay on 2.10.0. The backend's details stay out of scope for this changelog until it leaves Beta
 
 #### Bump aiohomematic-config to [2026.8.1](https://github.com/SukramJ/aiohomematic-config/compare/2026.8.0...2026.8.1)
 

--- a/custom_components/homematicip_local/generic_entity.py
+++ b/custom_components/homematicip_local/generic_entity.py
@@ -130,13 +130,16 @@ class AioHomematicGenericEntity(Entity, Generic[HmGenericDataPointProtocol]):
             and hm_device.has_sub_devices
             and (dp_channel := data_point.channel) is not None
             and dp_channel.is_in_multi_group
+            # No group master means no sub device to split off, and moving the
+            # via device up to the device itself would then make the device its
+            # own via device — which HA rejects with a HomeAssistantError that
+            # no platform catches. Stay on the device, below the central.
+            and (channel_group_master := dp_channel.group_master) is not None
         ):
             via_device = hm_device.identifier
-
-            if (channel_group_master := dp_channel.group_master) is not None:
-                identifier = f"{hm_device.identifier}-{channel_group_master.group_no}"
-                if (room := channel_group_master.room) is not None:
-                    suggested_area = room
+            identifier = f"{hm_device.identifier}-{channel_group_master.group_no}"
+            if (room := channel_group_master.room) is not None:
+                suggested_area = room
 
         if control_unit.enable_sub_devices and data_point.category in _SCHEDULE_CATEGORIES:
             via_device = hm_device.identifier

--- a/custom_components/homematicip_local/manifest.json
+++ b/custom_components/homematicip_local/manifest.json
@@ -12,8 +12,8 @@
   "loggers": ["aiohomematic", "aiohomematic_config", "openccu_loom_client"],
   "requirements": [
     "openccu-data==2026.7.2",
-    "openccu-loom-client==2026.8.27",
-    "aiohomematic-config==2026.8.0",
+    "openccu-loom-client==2026.8.29",
+    "aiohomematic-config==2026.8.1",
     "aiohomematic==2026.8.5"
   ],
   "ssdp": [

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -3,13 +3,13 @@
 async_upnp_client==0.48.1
 aiohomematic-test-support==2026.8.5
 aiohomematic==2026.8.5
-aiohomematic_config==2026.8.0
+aiohomematic_config==2026.8.1
 isal==1.8.0
 openccu-data>=2026.7.2
-openccu-loom-client==2026.8.27
+openccu-loom-client==2026.8.29
 mypy<=2.1.0
 prek==0.5.0
 pur==7.4.0
 pylint==4.0.7
 pylint_strict_informational==0.1
-pytest-homeassistant-custom-component-framework==1.0.47
+pytest-homeassistant-custom-component-framework==1.0.48

--- a/requirements_test_pre_commit.txt
+++ b/requirements_test_pre_commit.txt
@@ -1,5 +1,5 @@
 bandit==1.9.4
 codespell==2.4.3
 python-typing-update==v0.8.1
-ruff==0.16.4
+ruff==0.16.5
 yamllint==1.38.0

--- a/tests/test_generic_entity.py
+++ b/tests/test_generic_entity.py
@@ -173,6 +173,22 @@ class TestHaDeviceName:
 class TestScheduleSubdevice:
     """Tests for schedule sub-device creation logic."""
 
+    def test_multi_group_channel_without_group_master_stays_on_the_device(self) -> None:
+        """Test that a group-master-less channel does not make the device its own via device."""
+        mock_dp = _create_mock_data_point(category=DataPointCategory.SWITCH)
+        mock_dp.device.has_sub_devices = True
+        mock_dp.channel.is_in_multi_group = True
+        mock_dp.channel.group_master = None
+        mock_cu = _create_mock_control_unit(enable_sub_devices=True)
+        entity = _create_entity(mock_dp=mock_dp, mock_cu=mock_cu)
+
+        device_info = entity._attr_device_info
+        assert device_info is not None
+        # Without a group master there is no sub device to split off, so the
+        # entity stays on the device — which hangs off the central, not itself.
+        assert device_info["identifiers"] == {(DOMAIN, _DEVICE_IDENTIFIER)}
+        assert mock_cu.ensure_via_device_exists.call_args.kwargs["via_device"] == _CENTRAL_NAME
+
     def test_non_schedule_no_subdevice(self) -> None:
         """Test that non-schedule entities do not create a sub-device."""
         mock_dp = _create_mock_data_point(category=DataPointCategory.SWITCH)


### PR DESCRIPTION
Follow-up to the [device registry follow-up changes](https://developers.home-assistant.io/blog/2026/08/24/device-registry-follow-up-changes/), audited point by point against this integration.

## The one finding that needed a change

With sub devices enabled, `AioHomematicGenericEntity.__init__` moved the via device up to the Homematic device as soon as a channel reported `is_in_multi_group` — **before** resolving the group master that supplies the sub-device identifier:

```python
via_device = hm_device.identifier          # already moved up
if (channel_group_master := dp_channel.group_master) is not None:
    identifier = f"{hm_device.identifier}-{channel_group_master.group_no}"
```

Without a group master the identifier stayed on the device, so device and via device were identical. Blog point 5: HA used to ignore such a self-reference with a log line; since 2026.9 `async_get_or_create` raises `HomeAssistantError`, and `entity_platform` only catches `DeviceInfoError` — so the whole platform setup would go down rather than one entity being dropped.

The split is now conditional on the group master; a channel without one stays on its device, below the central.

**Honest scope:** not reproducible with the shipped test devices — 0 of 354 have a multi-group channel without a group master. This is a guard on a path our own code can produce, not a fix for an observed failure. The new test covers it, and fails without the change.

## Audit of the remaining points

Checked against the code, no change needed:

| Point | Status |
|---|---|
| 1, 3 `via_device` → `via_device_id` | done in 2.10.0 |
| 4 `ATTR_VIA_DEVICE` | not imported |
| 6 `merge_connections` / `merge_identifiers` | not used |
| 8 `devices` mapping access | done in 2.10.0; we use `async_entries_for_config_entry` / `async_get` |
| 9, 10 `child_devices`, `deleted_devices` | not used |
| 12 `async_is_composite_device_id` | not used |
| 13 entity needs unique id + config entry | measured: 0 of 4705 entities without a unique id |
| 15, 17 field plus `default_` counterpart, `default_*` | not used |
| 16 device name defaults to the config entry title | measured: 0 devices without a name; only the central carries the entry title, which is its actual name |
| 18 `created_at` / `modified_at` | not passed |

Points 2, 7, 11 and 14 add helpers or relax validation — nothing to migrate. `async_get_device_id_by_identifier()` (point 2) does not fit `ensure_via_device_exists()`, which has to create the via device when it is missing, while that helper raises `ValueError`.

**Verified:** `make prek` green, **921 passed, 8 skipped** (also with `--asyncio-mode=legacy`).