### PR TITLE
fix: stop retrying setup against an incompatible openccu-loom daemon

### DIFF
--- a/custom_components/homematicip_local/__init__.py
+++ b/custom_components/homematicip_local/__init__.py
@@ -25,7 +25,7 @@ from aiohomematic.support import find_free_port
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PORT, EVENT_HOMEASSISTANT_STOP, __version__ as HA_VERSION_STR
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.exceptions import ConfigEntryAuthFailed
+from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryError
 from homeassistant.helpers import device_registry as dr, entity_registry as er, issue_registry as ir
 from homeassistant.helpers.entity_registry import async_migrate_entries
 from homeassistant.helpers.issue_registry import async_delete_issue
@@ -132,6 +132,26 @@ def _any_entry_has_panel_enabled(*, hass: HomeAssistant) -> bool:
     return False
 
 
+class _NeverRaised(Exception):
+    """Placeholder type so an `except` clause can be written unconditionally."""
+
+
+def _loom_incompatible_version_error() -> type[Exception]:
+    """
+    Return the loom client's incompatible-version error, or an unraisable stand-in.
+
+    Imported lazily like every other `openccu_loom_client` reference in this
+    integration, and degraded to a type nothing raises when the package is
+    absent — the `except` clause then simply never matches, which is the
+    correct behaviour on a backend that has no daemon.
+    """
+    try:
+        from openccu_loom_client import LoomIncompatibleVersionError  # noqa: PLC0415
+    except ImportError:
+        return _NeverRaised
+    return LoomIncompatibleVersionError
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: HomematicConfigEntry) -> bool:
     """Set up Homematic(IP) Local for OpenCCU from a config entr11y."""
     # The openccu-loom backend talks to the daemon via openccu-loom-client
@@ -224,6 +244,21 @@ async def async_setup_entry(hass: HomeAssistant, entry: HomematicConfigEntry) ->
             entry.data.get(CONF_INSTANCE_NAME),
         )
         raise ConfigEntryAuthFailed("Authentication failed") from err
+    except _loom_incompatible_version_error() as err:
+        # Not a transient failure: the daemon on the other end speaks a
+        # contract this build cannot, and retrying reaches the same daemon
+        # with the same answer until somebody upgrades one side. Raising
+        # ConfigEntryError stops the retry loop and tells the user, where
+        # ConfigEntryNotReady would retry forever behind a spinner.
+        #
+        # Must be caught after AuthFailure and before any handler for the
+        # general loom transport error, which it subclasses.
+        _LOGGER.error(
+            "The openccu-loom daemon for %s is not compatible with this integration: %s",
+            entry.data.get(CONF_INSTANCE_NAME),
+            err,
+        )
+        raise ConfigEntryError(str(err)) from err
     if not is_loom_backend:
         await _async_reanchor_hub_unique_ids_on_serial_change(hass, entry, control)
     await async_setup_services(hass)


### PR DESCRIPTION
Setup catches only `AuthFailure`, so a daemon whose API version this build cannot speak falls through to the `ConfigEntryNotReady` path and retries forever — reaching the same daemon with the same answer behind a spinner. The user sees a config entry that never finishes and nothing saying why.

`openccu-loom-client` 2026.8.29 raises `LoomIncompatibleVersionError` for exactly this. It is the one condition here that does not clear on its own: it clears when somebody upgrades the daemon or the client, which is a `ConfigEntryError` to report rather than a state to wait out.

## Two ordering constraints

Both are easy to get wrong later, so they are stated in the code:

- it must sit **after** `AuthFailure`;
- and **before** any handler for the general loom transport error — `LoomIncompatibleVersionError` subclasses `LoomTransportError`, so a broad handler placed first would swallow the specific case and silently restore today's behaviour.

## Lazy resolution

The type is resolved through a small helper rather than imported at module level, matching how every other `openccu_loom_client` reference in this integration is loaded. When the package is absent it returns a type nothing raises, so the `except` clause is inert on a backend that has no daemon.

## Verification

- 921 passed, 8 skipped — the existing suite, unchanged
- ruff check / ruff format / mypy clean on the touched file
- the helper resolves to the real `LoomIncompatibleVersionError`, and `issubclass(..., LoomTransportError)` confirms the ordering constraint above is real rather than assumed