### PR TITLE
feat: describe the daemon-latency sensor, bump openccu-loom-client to 2026.8.32

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,9 +9,9 @@
 
 ### Dependencies
 
-#### Bump openccu-loom-client to `2026.8.31` (pins `openccu-loom-types==0.5.9`)
+#### Bump openccu-loom-client to `2026.8.32` (pins `openccu-loom-types==0.5.9`)
 
-- **This raises the minimum daemon to openccu-loom 0.66.1 or newer.** Bump for the openccu-loom backend (Beta); it has no runtime effect on the direct-CCU backend, where the client is not loaded. It completes reconnect recovery, adopts the daemon's onboarding release state and fixes a double-scaled `hs_color`; it is generated against daemon API 7.21.0, up from 7.13.0, which it checks at connect time — an older daemon is rejected outright. Installations that cannot update the daemon should stay on 2.10.0. The backend's details stay out of scope for this changelog until it leaves Beta
+- **This raises the minimum daemon to openccu-loom 0.66.1 or newer.** Bump for the openccu-loom backend (Beta); it has no runtime effect on the direct-CCU backend, where the client is not loaded. It completes reconnect recovery, adopts the daemon's onboarding release state, adds a sensor for the latency to the daemon, and fixes a double-scaled `hs_color`; it is generated against daemon API 7.21.0, up from 7.13.0, which it checks at connect time — an older daemon is rejected outright. Installations that cannot update the daemon should stay on 2.10.0. The backend's details stay out of scope for this changelog until it leaves Beta
 
 #### Bump aiohomematic to [2026.8.6](https://github.com/SukramJ/aiohomematic/compare/2026.8.5...2026.8.6)
 

--- a/custom_components/homematicip_local/entity_helpers/descriptions/hub.py
+++ b/custom_components/homematicip_local/entity_helpers/descriptions/hub.py
@@ -312,6 +312,28 @@ HUB_RULES: list[EntityDescriptionRule] = [
             suggested_display_precision=1,
         ),
     ),
+    # Round-trip latency to the daemon itself (openccu-loom backend only).
+    #
+    # Deliberately separate from the connection-latency rule above, which
+    # measures the daemon-to-CCU leg. The two have unrelated causes — a slow
+    # reverse proxy or a congested link between here and the daemon is
+    # invisible in the CCU figure, and a struggling CCU is invisible in this
+    # one — so they are two sensors rather than one, and each needs its own
+    # description. Matched on a literal because the singleton is loom-specific
+    # and aiohomematic has no constant for it.
+    EntityDescriptionRule(
+        category=DataPointCategory.HUB_SENSOR,
+        var_name_contains="daemon_latency",
+        description=diagnostic_sensor(
+            key="DAEMON_LATENCY",
+            device_class=SensorDeviceClass.DURATION,
+            unit=UnitOfTime.MILLISECONDS,
+            icon="mdi:lan-connect",
+            translation_key="daemon_latency",
+            enabled_default=True,
+            suggested_display_precision=1,
+        ),
+    ),
     EntityDescriptionRule(
         category=DataPointCategory.HUB_SENSOR,
         var_name_contains=METRICS_SENSOR_LAST_EVENT_AGE_NAME,

--- a/custom_components/homematicip_local/manifest.json
+++ b/custom_components/homematicip_local/manifest.json
@@ -12,7 +12,7 @@
   "loggers": ["aiohomematic", "aiohomematic_config", "openccu_loom_client"],
   "requirements": [
     "openccu-data==2026.7.2",
-    "openccu-loom-client==2026.8.31",
+    "openccu-loom-client==2026.8.32",
     "aiohomematic-config==2026.8.1",
     "aiohomematic==2026.8.6"
   ],

--- a/custom_components/homematicip_local/strings.json
+++ b/custom_components/homematicip_local/strings.json
@@ -396,6 +396,9 @@
             "cover_tilt": {
                 "name": "Tilt level"
             }, 
+            "daemon_latency": {
+                "name": "Daemon Latency"
+            }, 
             "direction": {
                 "name": "Direction", 
                 "state": {

--- a/custom_components/homematicip_local/translations/de.json
+++ b/custom_components/homematicip_local/translations/de.json
@@ -396,6 +396,9 @@
             "cover_tilt": {
                 "name": "Lamellenposition"
             }, 
+            "daemon_latency": {
+                "name": "Daemon-Latenz"
+            }, 
             "direction": {
                 "name": "Richtung", 
                 "state": {

--- a/custom_components/homematicip_local/translations/en.json
+++ b/custom_components/homematicip_local/translations/en.json
@@ -396,6 +396,9 @@
       "cover_tilt": {
         "name": "Tilt level"
       },
+      "daemon_latency": {
+          "name": "Daemon Latency"
+      },
       "direction": {
         "name": "Direction",
         "state": {

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -6,7 +6,7 @@ aiohomematic==2026.8.6
 aiohomematic_config==2026.8.1
 isal==1.8.0
 openccu-data>=2026.7.2
-openccu-loom-client==2026.8.31
+openccu-loom-client==2026.8.32
 mypy<=2.1.0
 prek==0.5.0
 pur==7.4.0

--- a/tests/test_entity_helper.py
+++ b/tests/test_entity_helper.py
@@ -8,10 +8,20 @@ from aiohomematic.const import DataPointCategory
 from custom_components.homematicip_local.entity_helpers import REGISTRY
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass
 from homeassistant.components.event import EventDeviceClass
+from homeassistant.components.sensor import SensorDeviceClass
+from homeassistant.const import UnitOfTime
 
 
 class TestEntityHelper:
     """Tests for entity helper functions."""
+
+    def test_daemon_and_ccu_latency_do_not_share_a_description(self) -> None:
+        """The rule must match the daemon sensor only, not the CCU one beside it."""
+        daemon = REGISTRY.find(category=DataPointCategory.HUB_SENSOR, var_name="daemon_latency")
+        ccu = REGISTRY.find(category=DataPointCategory.HUB_SENSOR, var_name="connection_latency")
+        assert daemon is not None
+        assert ccu is not None
+        assert daemon.key != ccu.key
 
     def test_registry_defaults(self) -> None:
         """Test that defaults are returned when no rule matches."""
@@ -66,6 +76,26 @@ class TestEntityHelper:
         assert description is not None
         assert description.key == "DAEMON_CONNECTION"
         assert description.device_class == BinarySensorDeviceClass.CONNECTIVITY
+
+    def test_registry_find_daemon_latency(self) -> None:
+        """
+        The client-to-daemon latency sensor is distinct from the CCU one.
+
+        Two legs with unrelated causes: a slow reverse proxy between Home
+        Assistant and the daemon is invisible in the CCU figure, and a
+        struggling CCU is invisible in this one. They are therefore two
+        sensors, and each needs its own description — without one the entity
+        renders with no unit, device class or icon.
+        """
+        description = REGISTRY.find(
+            category=DataPointCategory.HUB_SENSOR,
+            var_name="daemon_latency",
+        )
+
+        assert description is not None
+        assert description.key == "DAEMON_LATENCY"
+        assert description.device_class == SensorDeviceClass.DURATION
+        assert description.native_unit_of_measurement == UnitOfTime.MILLISECONDS
 
     @pytest.mark.parametrize("device_model", ["HmIP-DBB", "HmIP-DSD-PCB"])
     def test_registry_find_doorbell_event(self, device_model: str) -> None:


### PR DESCRIPTION
`openccu-loom-client` 2026.8.32 adds a sensor for the round trip to the daemon itself. Home Assistant matches entity descriptions on the stable English token, so without a rule the entity renders with no unit, no device class and no icon — the same gap the `daemon_connection` singleton had.

## Why a second sensor and not a second reading

`connection_latency` measures the **daemon → CCU** leg. This one measures **client → daemon**. The two have unrelated causes: a slow reverse proxy or a congested link between Home Assistant and the daemon is invisible in the CCU figure, and a struggling CCU is invisible in this one. Diagnosing either means being able to see them apart.

The rule matches on a literal, because the singleton is loom-specific and aiohomematic has no constant for it — the same shape the `daemon_connection` rule already uses.

## Tests

Two, and the second is the one that matters: the rule matches on a **substring**, and "latency" appears in both sensor names, so a careless pattern would have swallowed the CCU sensor too. One test resolves the description (duration, milliseconds); the other asserts the two do not share it.

## Also here

- `openccu-loom-client` 2026.8.31 → 2026.8.32 in the manifest and the test requirements, and the changelog line follows;
- `daemon_latency` translations in `strings.json`, `en.json` and `de.json`.

## One backlog correction

The client's backlog listed an entity description for `daemon_connection` as still open. It is not — that rule exists, with its own test. Checked before writing rather than carried over, which is why this PR does not touch it.

## Verification

923 passed, 8 skipped (+2). Full `prek run --all-files` clean, including the translation checks that would have caught a misplaced key.