### PR TITLE
Say when a loom twin is missing; correct the disproved docstring

### DIFF
--- a/custom_components/homematicip_local/backend_types.py
+++ b/custom_components/homematicip_local/backend_types.py
@@ -2,10 +2,23 @@
 
 With the openccu-loom backend the data points handed to the platforms
 are instances of openccu-loom-client's aiohomematic-*compatible*
-classes, not of aiohomematic's own classes. aiohomematic's
-Protocol-based metaclass blocks both subclassing (C-level slot-layout
-conflict) and ``ABCMeta.register`` virtual subclassing, so platform
-dispatch cannot rely on a shared class identity.
+classes, not of aiohomematic's own classes, and there is no way to make
+one class identity cover both.
+
+Not for the reason this docstring used to give. Subclassing an
+aiohomematic model class works — measured twice, 15 of 15 dispatch
+classes — so the "C-level slot-layout conflict" claim was wrong. Two
+other things are true and are what actually rule the alternatives out:
+
+* ``ABCMeta.register`` fails *silently*. ``CustomDpCover.register(cls)``
+  returns without error and ``isinstance`` stays ``False``, so a virtual
+  registration would read as working and dispatch nothing.
+* Inheriting is worse than useless. On a subclass that skips
+  ``__init__`` — which a daemon-mediated twin must, since aiohomematic's
+  constructors want a live ``CentralUnit`` — 93 of 153 members raise on
+  access, 42 of them public, including the ones the platforms read:
+  ``current_position``, ``is_closed``, ``unique_id``, ``name``,
+  ``available``, ``usage``.
 
 Instead, each dispatch checks ``isinstance`` against a tuple pairing the
 aiohomematic class with its openccu-loom-client twin. This is purely
@@ -18,6 +31,7 @@ aiohomematic class alone, so a CCU-only install is unaffected.
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING, Any, cast
 
 from aiohomematic.model.custom import (
@@ -58,6 +72,9 @@ else:
     _a = _loom_alarm_panel
 
 
+_LOGGER = logging.getLogger(__name__)
+
+
 def _pair[T](aio_cls: type[T], loom_attr: str, loom_module: object | None) -> tuple[type[T], ...]:
     """Return ``(aio_cls, loom_cls)`` if the loom twin exists, else ``(aio_cls,)``.
 
@@ -70,6 +87,17 @@ def _pair[T](aio_cls: type[T], loom_attr: str, loom_module: object | None) -> tu
         loom_cls = getattr(loom_module, loom_attr, None)
         if loom_cls is not None:
             return (aio_cls, cast("type[T]", loom_cls))
+        # The module imported, so openccu-loom-client is installed and this
+        # twin is expected — it has been renamed or removed. Degrading to the
+        # aiohomematic class alone would silently drop every loom entity of
+        # this type out of its platform: a blind loses tilt, a garage loses
+        # its class, a sound player loses its soundfiles, and nothing says so.
+        _LOGGER.warning(
+            "openccu-loom-client is installed but exposes no %s; entities of this type will not be "
+            "dispatched on the openccu-loom backend. This is a version mismatch between the "
+            "integration and openccu-loom-client",
+            loom_attr,
+        )
     return (aio_cls,)
 
 

--- a/docs/architecture-comparison-aiohomematic-vs-loom.md
+++ b/docs/architecture-comparison-aiohomematic-vs-loom.md
@@ -9,7 +9,7 @@ power (or are being prepared to power) the Home Assistant integration
    in-process inside Home Assistant.
 2. **OpenCCU-Loom** — a newer split architecture: a standalone **Go daemon**
    (`openccu-loom`) that owns the CCU connection and exposes a REST + WebSocket
-   API, consumed by a **thin Python client** (`openccu-loom-client`) whose
+   API, consumed by a **Python client** (`openccu-loom-client`) whose
    `compat/aiohomematic` layer mimics the aiohomematic API so the integration
    can use either backend.
 
@@ -17,6 +17,29 @@ power (or are being prepared to power) the Home Assistant integration
 integration v2.8.0): the Loom backend is **bundled but not user-selectable** —
 `LOOM_BACKEND_SELECTABLE = False` (`custom_components/homematicip_local/const.py:65`).
 It is groundwork for a future alternative, not a shipping feature.
+
+**Re-measured 2026-08-28.** The code-size rows in §1 and §7 were taken again
+with one method across all five packages — `wc -l` over package sources,
+excluding tests, `venv/`, `build/`, `*.egg-info/`, `__pycache__/`, and
+`*_test.go` on the Go side. Only those rows changed; nothing else here has
+been re-verified against the current tree, and the daemon versions cited
+further down (0.7.1 / API 1.18.0) are long superseded — daemon 0.67.1 and API
+7.23.0 at the time of writing.
+
+The number worth calling out, because this document leans on it: the loom
+client is no longer thin. It was ~14,000 LOC when this was written. It peaked
+at 22,663 and sits at **21,730** after a round of deletions, of which
+`compat/` is 10,034 — 46 %, up from 34.5 % three months earlier, and growing
+faster than the core. The "thin adapter" premise in the original §1 and §7 has
+eroded by about 55 %.
+
+That does not overturn this document's central claim. A two-round
+architecture review of the six coupled repositories (2026-08-28) tested
+exactly that claim and confirmed it: measured against the four deployment
+goals, moving the compat shim into this repository, turning the daemon's
+north surface into an HA entity projection, and generating the client's REST
+façade all failed. §13's *"Loom does not reduce complexity; it relocates it"*
+stands as written.
 
 > **Update (2026-07-31, integration v2.9.0).** The master switch was removed.
 > The config flow now offers the Loom backend when it is relevant: an
@@ -43,8 +66,8 @@ It is groundwork for a future alternative, not a shipping feature.
 | | `aiohomematic` (direct) | OpenCCU-Loom (daemon + thin client) |
 |---|---|---|
 | **Shape** | One in-process library, HA ↔ CCU | Standalone Go daemon between HA and CCU |
-| **Code size** | ~74,130 LOC Python (200 files) | Client ~13,985 LOC Python + types ~2,479 LOC + **daemon ~231,923 LOC Go** |
-| **HA-process footprint** | Heavy (full library) | Thin (~14k LOC adapter) |
+| **Code size** | ~72,730 LOC Python (199 files) | Client ~21,730 LOC Python + types ~6,033 LOC + **daemon ~329,997 LOC Go** |
+| **HA-process footprint** | Heavy (full library) | ~21.7k LOC adapter, 46 % of it the compat shim |
 | **South-bound (to CCU)** | XML-RPC + JSON-RPC | XML-RPC + **BIN-RPC** + JSON-RPC |
 | **North-bound (to HA)** | n/a (is in-process) | REST + WebSocket (JSON, delta push) |
 | **Inbound listener in HA?** | **Yes** (local XML-RPC callback server) | **No** (single outgoing WebSocket) |
@@ -331,8 +354,8 @@ pays an N×M REST fan-out between daemon and client on the first connect.
 
 | | `aiohomematic` | Loom |
 |---|---|---|
-| Lines in the HA process | ~74,130 (full library) | ~14,000 (thin adapter) |
-| Lines total in the system | ~74,130 | ~14,000 + ~2,479 + **~231,923 (daemon)** |
+| Lines in the HA process | ~72,730 (full library) | ~21,730 (adapter) |
+| Lines total in the system | ~72,730 | ~21,730 + ~6,033 + **~329,997 (daemon)** |
 | Heavy logic location | in-process | in the Go daemon |
 | Moving parts | 1 | 3 (daemon, client, types) + SQLite |
 | Language(s) | Python | Go (daemon) + Python (client) |

--- a/tests/contract/test_backend_surface_contract.py
+++ b/tests/contract/test_backend_surface_contract.py
@@ -507,10 +507,13 @@ def _is_concrete_model_class(module_name: str, symbol: str) -> bool:
 def test_no_bare_aiohomematic_isinstance_dispatch() -> None:
     """Contract: platforms never isinstance-dispatch on concrete aiohomematic model classes.
 
-    A loom data point is never an instance of an aiohomematic class (the
-    Protocol metaclass blocks subclassing), so such a check silently excludes
-    the loom backend. Dispatch must go through the paired tuples in
-    ``backend_types.py`` or runtime-checkable Protocols.
+    A loom data point is never an instance of an aiohomematic class — not
+    because subclassing is blocked (it is not; see ``backend_types.py`` for
+    what actually rules the alternatives out) but because the twins do not
+    subclass, and cannot: aiohomematic's constructors want a live
+    ``CentralUnit``. So a bare check silently excludes the loom backend.
+    Dispatch must go through the paired tuples in ``backend_types.py`` or
+    runtime-checkable Protocols.
     """
     violations: list[str] = []
     for source in _integration_sources():


### PR DESCRIPTION
Closes #1264 and #1265.

## `_pair` degraded silently

If the loom module imported, openccu-loom-client is installed and the twin is expected — so its absence is a version mismatch between this integration and that package. `_pair` fell back to `(aio_cls,)` without a word, and the resulting failure is invisible: every loom entity of that type drops out of its platform dispatch. A blind loses tilt, a garage loses its class, a sound player loses its soundfiles. No error, no log, no test.

It warns now, naming the missing attribute. Verified the path actually fires rather than assuming it.

## The docstring's reason was half wrong

It said aiohomematic's Protocol metaclass "blocks both subclassing (C-level slot-layout conflict) and `ABCMeta.register` virtual subclassing". Subclassing works — measured twice, 15 of 15 dispatch classes. Two other things are true, and they are the ones worth writing down, because this question gets reopened every few months:

* `ABCMeta.register` fails **silently**: `register()` returns without error and `isinstance` stays `False`, so a virtual registration reads as working and dispatches nothing.
* Inheriting is worse than useless: on a subclass that skips `__init__` — which a daemon-mediated twin must, since aiohomematic's constructors want a live `CentralUnit` — 93 of 153 members raise on access, 42 of them public, including every one the platforms read (`current_position`, `is_closed`, `unique_id`, `name`, `available`, `usage`).

The same claim was repeated in `tests/contract/test_backend_surface_contract.py`; corrected there too.

## The comparison document's numbers

`docs/architecture-comparison-aiohomematic-vs-loom.md` leans on the loom client being thin. Re-measured with one method across all five packages: it was ~14,000 LOC when written, peaked at 22,663, and sits at **21,730** after a round of deletions — of which `compat/` is 10,034, i.e. 46 %, up from 34.5 % three months earlier. The premise has eroded by about 55 %.

Its central claim is **not** softened. A two-round architecture review tested exactly it and confirmed it: moving the compat shim into this repository, turning the daemon's north surface into an HA entity projection, and generating the client's REST façade all failed against the four deployment goals. §13's *"Loom does not reduce complexity; it relocates it"* stands as written. Only the numbers it hangs on needed to be right, and the note says which rows were re-verified and which were not.