### PR TITLE
Scope CUxD entity unique_ids by the central, on both backends

### DIFF
--- a/custom_components/homematicip_local/__init__.py
+++ b/custom_components/homematicip_local/__init__.py
@@ -6,6 +6,7 @@ from collections.abc import Callable
 import contextlib
 from dataclasses import dataclass
 import logging
+import re
 import time
 from typing import Any, TypeAlias
 
@@ -197,6 +198,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: HomematicConfigEntry) ->
     # For the openccu-loom backend, migrate any legacy aiohomematic entity
     # unique_ids to the canonical loom/serial scheme before entities are
     # (re)created, so existing entities keep their identity on cutover.
+    central_id = (entry.unique_id or entry.entry_id)[-10:].lower()
     if is_loom_backend:
         await _async_migrate_loom_unique_ids(hass, entry)
     else:
@@ -204,6 +206,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: HomematicConfigEntry) ->
         # legacy entry_id-anchored hub keys onto the CCU-serial scheme.
         await _async_restore_aiohomematic_unique_ids(hass, entry)
         await _async_migrate_aiohomematic_hub_unique_ids(hass, entry)
+    # Both backends inherited CUxD keys without the central-id slot; scope them
+    # once. Runs after the scheme migrations above so it sees final-shape keys.
+    await _async_migrate_cuxd_unique_ids(
+        hass, entry, namespace="loom_" if is_loom_backend else "", central_id=central_id
+    )
 
     hass.data.setdefault(HM_KEY, HomematicData())
     if (default_callback_port_xml_rpc := hass.data[HM_KEY].default_callback_port_xml_rpc) is None:
@@ -408,6 +415,95 @@ def _loom_migrated_unique_id(unique_id: str, *, entry_suffix: str, serial_suffix
     if key.startswith(entry_prefix):
         return f"{prefix}loom_{serial_suffix}_{key[len(entry_prefix) :]}"
     return f"{prefix}loom_{key}"
+
+
+# A CUxD serial is ``CUX`` + a two-digit device type + a five-digit running
+# number, so ``CUX2801001`` — the first "(28) System" device on essentially
+# every install. The shape is what makes the family recognisable in a routing
+# key regardless of what prefix precedes it (``calculated_``,
+# ``week_profile_``, ``schedule_channel_switch_``).
+_CUXD_KEY = re.compile(r"(?:^|_)cux\d{7}(?:_|$)")
+
+
+def _cuxd_scoped_unique_id(unique_id: str, *, namespace: str, central_id: str) -> str | None:
+    """Insert the central-id slot into a CUxD routing key, or ``None`` if not needed.
+
+    CUxD hands out the same synthetic addresses on every CCU, so two CCUs
+    bridged into one Home Assistant declared byte-identical unique_ids for
+    their CUxD data points and HA kept only the first. aiohomematic 2026.8.7
+    scopes the family by central id, as the daemon always had; every CUxD
+    entity keyed before that adoption therefore has to move once.
+
+    ``namespace`` is ``"loom_"`` on the openccu-loom backend and ``""`` on the
+    direct-CCU one — the loom scheme carries the serial *after* its namespace
+    (``loom_<serial>_cux…``) while aiohomematic carries the central id at the
+    front (``<central>_cux…``).
+
+    Idempotent: a key already carrying the slot is left alone, so this is safe
+    on every setup rather than only the first after the upgrade.
+    """
+    prefix = f"{DOMAIN}_"
+    if not unique_id.startswith(prefix):
+        return None
+    key = unique_id[len(prefix) :]
+    if namespace:
+        if not key.startswith(namespace):
+            return None
+        key = key[len(namespace) :]
+    elif key.startswith("loom_"):
+        # A loom key on the direct-CCU path is not ours to touch here.
+        return None
+    if not _CUXD_KEY.search(key):
+        return None
+    if key.startswith(f"{central_id}_"):  # already scoped
+        return None
+    return f"{prefix}{namespace}{central_id}_{key}"
+
+
+async def _async_migrate_cuxd_unique_ids(
+    hass: HomeAssistant, entry: HomematicConfigEntry, *, namespace: str, central_id: str
+) -> None:
+    """Scope CUxD entity unique_ids by the central id, once.
+
+    Runs on both backends, because both inherited the unscoped key: the daemon
+    always scoped CUxD, but the openccu-loom client rebuilds the keys the
+    daemon does not stamp — custom data points, week profiles, the combined
+    duration number, the device-update entity, event groups — through
+    aiohomematic, and aiohomematic did not scope them until 2026.8.7. On the
+    direct-CCU backend every CUxD entity is affected.
+
+    Without this the entities orphan: they keep their history, area and
+    customisations in the registry while the platform spawns freshly keyed
+    duplicates beside them, and the orphan-cleanup sweep eventually deletes
+    the originals. An installation with no CUxD devices sees nothing happen.
+    """
+    if not central_id:
+        return
+    entity_registry = er.async_get(hass)
+
+    @callback
+    def _migrator(entity_entry: er.RegistryEntry) -> dict[str, str] | None:
+        new_unique_id = _cuxd_scoped_unique_id(entity_entry.unique_id, namespace=namespace, central_id=central_id)
+        if new_unique_id is None or new_unique_id == entity_entry.unique_id:
+            return None
+        # HA raises on a duplicate unique_id, which would abort the whole
+        # migration and fail setup — skip instead (same guard as the other
+        # passes). The duplicate is the one without history; it loses.
+        if entity_registry.async_get_entity_id(entity_entry.domain, entity_entry.platform, new_unique_id):
+            _LOGGER.warning(
+                "Skipping CUxD unique_id migration, target already exists: %s -> %s",
+                entity_entry.unique_id,
+                new_unique_id,
+            )
+            return None
+        _LOGGER.info(
+            "Scoping CUxD unique_id by central: %s -> %s",
+            entity_entry.unique_id,
+            new_unique_id,
+        )
+        return {"new_unique_id": new_unique_id}
+
+    await async_migrate_entries(hass, entry.entry_id, _migrator)
 
 
 async def _async_migrate_loom_unique_ids(hass: HomeAssistant, entry: HomematicConfigEntry) -> None:

--- a/custom_components/homematicip_local/manifest.json
+++ b/custom_components/homematicip_local/manifest.json
@@ -14,7 +14,7 @@
     "openccu-data==2026.7.2",
     "openccu-loom-client==2026.8.32",
     "aiohomematic-config==2026.8.1",
-    "aiohomematic==2026.8.6"
+    "aiohomematic==2026.8.7"
   ],
   "ssdp": [
     {

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,8 +1,8 @@
 -r requirements_test_pre_commit.txt
 
 async_upnp_client==0.48.1
-aiohomematic-test-support==2026.8.6
-aiohomematic==2026.8.6
+aiohomematic-test-support==2026.8.7
+aiohomematic==2026.8.7
 aiohomematic_config==2026.8.1
 isal==1.8.0
 openccu-data>=2026.7.2

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -17,6 +17,7 @@ from custom_components.homematicip_local import (
     _async_migrate_loom_unique_ids,
     _async_reanchor_hub_unique_ids_on_serial_change,
     _async_restore_aiohomematic_unique_ids,
+    _cuxd_scoped_unique_id,
     _loom_migrated_unique_id,
 )
 from custom_components.homematicip_local.config_flow import DomainConfigFlow
@@ -741,6 +742,70 @@ async def test_cleanup_orphan_entries_removes_hub_anchored_entry_regardless_of_d
     ControlUnit._async_cleanup_orphaned_entity_registry_entries(fake_self)
 
     assert entity_registry.async_get(hub_orphan.entity_id) is None
+
+
+class TestCuxdUniqueIdScoping:
+    """``_cuxd_scoped_unique_id`` inserts the central-id slot into CUxD keys.
+
+    CUxD hands out the same synthetic addresses on every CCU — the first
+    "(28) System" device is ``CUX2801001`` on essentially every install — so
+    two bridged CCUs declared byte-identical unique_ids and Home Assistant
+    kept only the first. aiohomematic 2026.8.7 scopes the family, as the
+    daemon always had, so every CUxD entity keyed before that moves once.
+    """
+
+    _D = HMIP_DOMAIN
+    _CENTRAL = "abc1234567"
+
+    @pytest.mark.parametrize(
+        ("unique_id", "namespace"),
+        [
+            # Already scoped — the pass runs on every setup, so this matters.
+            (f"{_D}_abc1234567_cux2801001_1_state", ""),
+            (f"{_D}_loom_abc1234567_cux2801001_1_state", "loom_"),
+            # Not a CUxD address.
+            (f"{_D}_vcu1234567_1_state", ""),
+            (f"{_D}_loom_vcu1234567_1_state", "loom_"),
+            # A loom key reached on the direct-CCU path is not ours to touch.
+            (f"{_D}_loom_cux2801001_1_state", ""),
+            # Daemon-computed alarm-panel ids carry no routing key at all.
+            (f"{_D}_openccu-loom_alarm_55f96726", "loom_"),
+            # Another integration's entity in the same registry.
+            ("other_integration_cux2801001_1_state", ""),
+        ],
+    )
+    def test_leaves_everything_else_alone(self, unique_id: str, namespace: str) -> None:
+        assert _cuxd_scoped_unique_id(unique_id, namespace=namespace, central_id=self._CENTRAL) is None
+
+    @pytest.mark.parametrize(
+        ("unique_id", "namespace", "expected"),
+        [
+            # Direct-CCU backend: the central id goes at the front.
+            (f"{_D}_cux2801001_1_state", "", f"{_D}_abc1234567_cux2801001_1_state"),
+            # …including behind a routing-key prefix, which is why the family
+            # is matched on the CUX serial shape rather than on a leading
+            # substring.
+            (
+                f"{_D}_calculated_cux2801001_1_state",
+                "",
+                f"{_D}_abc1234567_calculated_cux2801001_1_state",
+            ),
+            # openccu-loom backend: after the namespace, not before it.
+            (
+                f"{_D}_loom_cux2801001_1_state",
+                "loom_",
+                f"{_D}_loom_abc1234567_cux2801001_1_state",
+            ),
+        ],
+    )
+    def test_scopes_a_cuxd_key(self, unique_id: str, namespace: str, expected: str) -> None:
+        assert _cuxd_scoped_unique_id(unique_id, namespace=namespace, central_id=self._CENTRAL) == expected
+
+    def test_scoping_is_idempotent(self) -> None:
+        """Applying the rewrite to its own output is a no-op."""
+        once = _cuxd_scoped_unique_id(f"{self._D}_cux2801001_1_state", namespace="", central_id=self._CENTRAL)
+        assert once is not None
+        assert _cuxd_scoped_unique_id(once, namespace="", central_id=self._CENTRAL) is None
 
 
 class TestLoomUniqueIdMigration:


### PR DESCRIPTION
Closes the first half of #126. The sysvar rekey to `ise_id` stays a separate wave, as decided.

## Why now

aiohomematic 2026.8.7 scopes `CUX*` addresses by the central id, as the daemon always had. CUxD hands out the same synthetic addresses on every CCU — the first `(28) System` device is `CUX2801001` on essentially every install — so two CCUs bridged into one Home Assistant declared byte-identical unique_ids for their CUxD data points, and HA kept only the first.

Every CUxD entity keyed before that adoption has to move once. Without a migration it does not move: it **orphans**, keeping its history, area and customisations in the registry while the platform spawns a freshly keyed duplicate beside it, until the orphan-cleanup sweep deletes the original.

`manifest.json` and `requirements_test.txt` already carried the 2026.8.7 bump in the working tree when this was branched. They ride along deliberately — the migration has to land **with** the bump that makes it necessary, not after it.

## Why a third pass

Both backends are affected:

- **direct CCU** — every CUxD entity, since aiohomematic produced the whole key;
- **openccu-loom** — the keys the client rebuilds because the daemon does not stamp them: custom data points, week profiles, the combined duration number, the device-update entity, event groups. Generic data points use the daemon's `unique_id` and never moved.

And the two schemes need different surgery. aiohomematic carries the central id at the front (`<central>_cux…`); the loom scheme carries it *after* its namespace (`loom_<serial>_cux…`).

`_loom_migrated_unique_id` cannot host this: it returns early on anything already starting with `loom_`, which is exactly the population that needs the rewrite.

## Details worth a look

The family is matched on the **CUxD serial shape** — `CUX` plus seven digits — rather than on a leading substring, because a routing key may carry a prefix first (`calculated_cux2801001_1_state`, `week_profile_cux…`). Matching on `startswith` would have missed those.

Idempotent, entry-scoped and collision-safe like the passes beside it, so it runs on every setup rather than only the first after the upgrade. An installation with no CUxD devices sees nothing happen.

Ten cases covered, including both idempotency directions, a loom key reached on the direct-CCU path, the daemon-computed `openccu-loom_alarm_*` ids, and another integration's entity sharing the registry.

934 tests, ruff, mypy and pylint pass.