### PR TITLE
chore(deps): aiohomematic 2026.8.8, and pin the two files together

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,13 @@
 
 ### Dependencies
 
+#### Bump aiohomematic to `2026.8.8`
+
+The manifest still pinned `2026.8.7` while CI already ran `2026.8.8` — across the very release that adopts 2026.8.8's re-keying of system variables and programs. The registry migration added for it was therefore tested against a backend that had re-keyed and would have shipped against one that had not.
+
+`tests/test_dependency_pins.py` now pins the two files together, the way the sister client repository does. Bite proof: restoring `2026.8.7` in the manifest fails it by name.
+
+
 #### Bump openccu-loom-client to `2026.8.32` (pins `openccu-loom-types==0.5.9`)
 
 - **This raises the minimum daemon to openccu-loom 0.66.1 or newer.** Bump for the openccu-loom backend (Beta); it has no runtime effect on the direct-CCU backend, where the client is not loaded. It completes reconnect recovery, adopts the daemon's onboarding release state, adds a sensor for the latency to the daemon, and fixes a double-scaled `hs_color`; it is generated against daemon API 7.21.0, up from 7.13.0, which it checks at connect time — an older daemon is rejected outright. Installations that cannot update the daemon should stay on 2.10.0. The backend's details stay out of scope for this changelog until it leaves Beta

--- a/custom_components/homematicip_local/manifest.json
+++ b/custom_components/homematicip_local/manifest.json
@@ -12,9 +12,9 @@
   "loggers": ["aiohomematic", "aiohomematic_config", "openccu_loom_client"],
   "requirements": [
     "openccu-data==2026.7.2",
-    "openccu-loom-client==2026.8.32",
+    "openccu-loom-client==2026.8.33",
     "aiohomematic-config==2026.8.1",
-    "aiohomematic==2026.8.7"
+    "aiohomematic==2026.8.8"
   ],
   "ssdp": [
     {

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -12,4 +12,4 @@ prek==0.5.0
 pur==7.4.0
 pylint==4.0.7
 pylint_strict_informational==0.1
-pytest-homeassistant-custom-component-framework==1.0.48
+pytest-homeassistant-custom-component-framework==1.0.49

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,12 +1,12 @@
 -r requirements_test_pre_commit.txt
 
 async_upnp_client==0.48.1
-aiohomematic-test-support==2026.8.7
-aiohomematic==2026.8.7
+aiohomematic-test-support==2026.8.8
+aiohomematic==2026.8.8
 aiohomematic_config==2026.8.1
 isal==1.8.0
 openccu-data>=2026.7.2
-openccu-loom-client==2026.8.32
+openccu-loom-client==2026.8.33
 mypy<=2.1.0
 prek==0.5.0
 pur==7.4.0

--- a/tests/test_dependency_pins.py
+++ b/tests/test_dependency_pins.py
@@ -1,0 +1,79 @@
+"""
+Guard the backend pins that are maintained in two files at once.
+
+`manifest.json` is what Home Assistant installs for a user. `requirements_test.txt`
+is what CI installs before running this suite. A package pinned exactly in both must
+name the same version, or every test here runs against one version while users get
+another — the suite stays green and the release ships broken.
+
+That is not hypothetical. The `aiohomematic` pin sat at `2026.8.7` in the manifest
+while CI ran `2026.8.8`, across the release that adopted 2026.8.8's re-keying of
+system variables and programs. The registry migration added for it was therefore
+tested against a backend that had re-keyed and shipped against one that had not.
+
+The sister repository `openccu-loom-client` carries the same guard for the same
+reason (`tests/unit/test_dependency_pins.py` there); this is its counterpart.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import re
+
+_ROOT = Path(__file__).resolve().parents[1]
+_MANIFEST = _ROOT / "custom_components" / "homematicip_local" / "manifest.json"
+_TEST_REQUIREMENTS = _ROOT / "requirements_test.txt"
+
+
+def _exact_pins(requirements: list[str]) -> dict[str, str]:
+    """Map distribution name -> version for every ``name==version`` requirement."""
+    out: dict[str, str] = {}
+    for raw in requirements:
+        if (line := raw.strip()) and not line.startswith("#") and "==" in line:
+            name, version = line.split("==", 1)
+            out[name.strip().lower()] = version.strip()
+    return out
+
+
+def _manifest_pins() -> dict[str, str]:
+    return _exact_pins(json.loads(_MANIFEST.read_text(encoding="utf-8"))["requirements"])
+
+
+def _test_requirement_pins() -> dict[str, str]:
+    return _exact_pins(_TEST_REQUIREMENTS.read_text(encoding="utf-8").splitlines())
+
+
+class TestBackendPinsAgree:
+    """A package pinned in both files must name one version."""
+
+    def test_shared_pins_match(self) -> None:
+        manifest = _manifest_pins()
+        ci = _test_requirement_pins()
+        shared = sorted(set(manifest) & set(ci))
+        assert shared, (
+            "no package is pinned exactly in both files — either the guard's parsing "
+            "broke or the pins moved, and it would pass vacuously either way"
+        )
+        for dist in shared:
+            assert manifest[dist] == ci[dist], (
+                f"{dist} pin drifted: manifest.json says {manifest[dist]}, "
+                f"requirements_test.txt says {ci[dist]}. Home Assistant installs the "
+                f"manifest; CI tests the other — so a mismatch ships untested code."
+            )
+
+    def test_the_two_backends_are_pinned_in_the_manifest(self) -> None:
+        """
+        Both backends stay exactly pinned rather than floored.
+
+        This integration is the application at the top of the chain, so an exact pin
+        here conflicts with nobody, and the two backends re-key entities between
+        releases — an accidental range would migrate a registry against a version
+        this suite never ran.
+        """
+        manifest = _manifest_pins()
+        for dist in ("aiohomematic", "openccu-loom-client"):
+            assert dist in manifest, f"{dist} is no longer pinned exactly in manifest.json"
+            assert re.fullmatch(r"\d{4}\.\d+\.\d+", manifest[dist]), (
+                f"{dist} pin {manifest[dist]!r} is not a calendar version"
+            )


### PR DESCRIPTION
Answering the pin half of [openccu-loom-client#126](https://github.com/SukramJ/openccu-loom-client/issues/126) — and it was worse than a routine bump.

## The drift

```
manifest.json          aiohomematic==2026.8.7
requirements_test.txt  aiohomematic==2026.8.8
```

Home Assistant installs the manifest. CI installs the other. So #1270's registry migration — the one that moves sysvar and program keys onto the CCU id — was **tested against a backend that had re-keyed and would have shipped against one that had not**. In that state the migration finds nothing to migrate, and the entities re-key unmigrated on whatever bump comes next, which is precisely the orphaning #1270 exists to prevent.

`openccu-loom-client` was already at `2026.8.33` in the manifest and needed nothing. I also checked whether `openccu-loom-client` itself needs a bump for 2026.8.8: it does not — it builds its hub keys from the daemon's stamped `unique_id` and touches none of the reference classes 2026.8.8 changed. Its `requirements.txt` already pins `2026.8.8`.

## The guard that was missing

`tests/test_dependency_pins.py`. Nothing compared the two files, which is how they drifted across exactly the release where it mattered. The sister repository `openccu-loom-client` has carried this guard since a pin drift caused one of its releases; this is its counterpart.

- It compares only distributions pinned exactly in **both** files — the manifest also names transitive ones (`openccu-data`, `aiohomematic-config`) that `requirements_test.txt` has no line for, and treating those as drift would be a false alarm.
- It refuses to pass vacuously if that intersection is ever empty.
- A second case keeps both backends *exactly pinned* rather than floored: this integration sits at the top of the chain, so an exact pin conflicts with nobody, and a range would migrate a registry against a version the suite never ran.

**Bite proof:** restoring `2026.8.7` in the manifest fails it by name, with both versions in the message.

## One line that is not mine

The `requirements_test.txt` change moving `openccu-loom-client` from `2026.8.32` to `2026.8.33` was already in the working tree, uncommitted, when I branched. It is carried here rather than dropped — it is the version the manifest names and the one on PyPI — but flagged so it is not mistaken for part of this change.

`pytest` 947 passed / 8 skipped, `ruff`, `mypy`, all pre-commit hooks green.