### PR TITLE
Bump openccu-loom-client to 2026.8.34

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -20,9 +20,12 @@ The manifest still pinned `2026.8.7` while CI already ran `2026.8.8` — across 
 `tests/test_dependency_pins.py` now pins the two files together, the way the sister client repository does. Bite proof: restoring `2026.8.7` in the manifest fails it by name.
 
 
-#### Bump openccu-loom-client to `2026.8.32` (pins `openccu-loom-types==0.5.9`)
+#### Bump openccu-loom-client to `2026.8.34`
 
-- **This raises the minimum daemon to openccu-loom 0.66.1 or newer.** Bump for the openccu-loom backend (Beta); it has no runtime effect on the direct-CCU backend, where the client is not loaded. It completes reconnect recovery, adopts the daemon's onboarding release state, adds a sensor for the latency to the daemon, and fixes a double-scaled `hs_color`; it is generated against daemon API 7.21.0, up from 7.13.0, which it checks at connect time — an older daemon is rejected outright. Installations that cannot update the daemon should stay on 2.10.0. The backend's details stay out of scope for this changelog until it leaves Beta
+- **This raises the minimum daemon to openccu-loom 0.67.0 or newer.** Bump for the openccu-loom backend (Beta); it has no runtime effect on the direct-CCU backend, where the client is not loaded. The client is generated against daemon API 7.23.0, up from 7.13.0, and checks it at connect time — an older daemon is rejected outright rather than half-working. Installations that cannot update the daemon should stay on 2.10.0.
+- **CUxD entities re-key once**, and the migration for it is in this release. The client's own key rebuild now scopes `CUX*` addresses by the central, matching what the daemon always emitted; without the pass those entities would have orphaned instead of moving. An installation without CUxD devices sees nothing.
+- The client no longer ships `openccu-loom-types` as a separate dependency — it is folded in — so this bump removes a package from the install rather than pinning one. It also floors `aiohomematic` at `2026.8.8`, which this release already pins.
+- The rest is not user-visible from here: a bootstrap that is one request instead of one per device, six admin API façades and thirteen unreachable modules removed from the wheel. The backend's details stay out of scope for this changelog until it leaves Beta.
 
 #### Bump aiohomematic to [2026.8.6](https://github.com/SukramJ/aiohomematic/compare/2026.8.5...2026.8.6)
 

--- a/custom_components/homematicip_local/manifest.json
+++ b/custom_components/homematicip_local/manifest.json
@@ -12,7 +12,7 @@
   "loggers": ["aiohomematic", "aiohomematic_config", "openccu_loom_client"],
   "requirements": [
     "openccu-data==2026.7.2",
-    "openccu-loom-client==2026.8.33",
+    "openccu-loom-client==2026.8.34",
     "aiohomematic-config==2026.8.1",
     "aiohomematic==2026.8.8"
   ],

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -6,7 +6,7 @@ aiohomematic==2026.8.8
 aiohomematic_config==2026.8.1
 isal==1.8.0
 openccu-data>=2026.7.2
-openccu-loom-client==2026.8.33
+openccu-loom-client==2026.8.34
 mypy<=2.1.0
 prek==0.5.0
 pur==7.4.0


### PR DESCRIPTION
Both pinned files were already edited in the working tree; this commits them and gives the bump a changelog entry — which the previous jump to 2026.8.33 never got. The entry still described `2026.8.32`, so it now covers the whole span.

## What a user needs to know

**The minimum daemon moves to openccu-loom 0.67.0.** The client is generated against API 7.23.0 (up from 7.13.0) and checks it at connect time, so an older daemon is rejected outright rather than half-working. Installations that cannot update the daemon should stay on 2.10.0.

**CUxD entities re-key once**, and the migration for it is already in this release (#1268). The client's key rebuild scopes `CUX*` addresses by the central now, matching what the daemon always emitted; without the pass those registry entries would have orphaned rather than moved. An installation without CUxD devices sees nothing.

## Two things that make this bump smaller than it looks

`openccu-loom-types` is **no longer a separate dependency** — it is folded into the client — so this removes a package from the install rather than pinning one. The old entry's parenthetical (`pins openccu-loom-types==0.5.9`) is gone with it.

And the client floors `aiohomematic` at `2026.8.8`, which this release already pins exactly. Satisfiable — and worth noting because that floor was raised deliberately, to stop an install pairing a current client with a reference old enough to key hub entities the other way. Pinning *older* than the floor here is the one thing that would not resolve, and that would be a lag chosen rather than fallen into.

The rest is not user-visible from the integration: a bootstrap that is one request instead of one per device, six admin API façades and thirteen unreachable modules removed from the wheel.

947 tests, ruff and mypy pass against the pinned set; `tests/test_dependency_pins.py` confirms the manifest and the test requirements agree.