### PR TITLE
Bump openccu-loom-client to 2026.8.35

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -20,8 +20,9 @@ The manifest still pinned `2026.8.7` while CI already ran `2026.8.8` — across 
 `tests/test_dependency_pins.py` now pins the two files together, the way the sister client repository does. Bite proof: restoring `2026.8.7` in the manifest fails it by name.
 
 
-#### Bump openccu-loom-client to `2026.8.34`
+#### Bump openccu-loom-client to `2026.8.35`
 
+- **Fixes a refresh that raised instead of refreshing.** On the openccu-loom backend, 2026.8.33 and 2026.8.34 failed to add any entity whose custom data point refreshes on start-up — switches, covers, lights, thermostats — because the client validated the wrong response shape for a single custom data point. Nobody should run those two versions on this backend; this release is the reason.
 - **This raises the minimum daemon to openccu-loom 0.67.0 or newer.** Bump for the openccu-loom backend (Beta); it has no runtime effect on the direct-CCU backend, where the client is not loaded. The client is generated against daemon API 7.23.0, up from 7.13.0, and checks it at connect time — an older daemon is rejected outright rather than half-working. Installations that cannot update the daemon should stay on 2.10.0.
 - **CUxD entities re-key once**, and the migration for it is in this release. The client's own key rebuild now scopes `CUX*` addresses by the central, matching what the daemon always emitted; without the pass those entities would have orphaned instead of moving. An installation without CUxD devices sees nothing.
 - The client no longer ships `openccu-loom-types` as a separate dependency — it is folded in — so this bump removes a package from the install rather than pinning one. It also floors `aiohomematic` at `2026.8.8`, which this release already pins.

--- a/custom_components/homematicip_local/manifest.json
+++ b/custom_components/homematicip_local/manifest.json
@@ -12,7 +12,7 @@
   "loggers": ["aiohomematic", "aiohomematic_config", "openccu_loom_client"],
   "requirements": [
     "openccu-data==2026.7.2",
-    "openccu-loom-client==2026.8.34",
+    "openccu-loom-client==2026.8.35",
     "aiohomematic-config==2026.8.1",
     "aiohomematic==2026.8.8"
   ],

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -6,10 +6,10 @@ aiohomematic==2026.8.8
 aiohomematic_config==2026.8.1
 isal==1.8.0
 openccu-data>=2026.7.2
-openccu-loom-client==2026.8.34
+openccu-loom-client==2026.8.35
 mypy<=2.1.0
 prek==0.5.0
 pur==7.4.0
-pylint==4.0.7
+pylint==4.0.8
 pylint_strict_informational==0.1
 pytest-homeassistant-custom-component-framework==1.0.49


### PR DESCRIPTION
**Fixes a regression that is live in the two previously pinned versions.**

On the openccu-loom backend, 2026.8.33 and 2026.8.34 fail to add any entity whose custom data point refreshes on start-up — switches, covers, lights, thermostats. The client validated the wrong response shape for `GET /devices/{addr}/cdps/{name}` and raised on every real response; one installation lost 22 entities that way, which is how it was found.

Nobody should run those two versions on this backend, so the changelog entry leads with that rather than with the version number. The direct-CCU backend is unaffected — the client is not loaded there.

Details and the fix: SukramJ/openccu-loom-client#143.

950 tests and mypy pass against the pinned set; `tests/test_dependency_pins.py` confirms the manifest and the test requirements agree.