### PR TITLE
fix(init): re-key hub entities before the platforms come up

### DIFF
--- a/custom_components/homematicip_local/__init__.py
+++ b/custom_components/homematicip_local/__init__.py
@@ -242,7 +242,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: HomematicConfigEntry) ->
         default_callback_port_xml_rpc=default_callback_port_xml_rpc,
     ).create_control_unit()
     entry.runtime_data = control
-    await hass.config_entries.async_forward_entry_setups(entry, HMIP_LOCAL_PLATFORMS)
     try:
         await control.start_central()
     except AuthFailure as err:
@@ -268,6 +267,17 @@ async def async_setup_entry(hass: HomeAssistant, entry: HomematicConfigEntry) ->
         raise ConfigEntryError(str(err)) from err
     if not is_loom_backend:
         await _async_reanchor_hub_unique_ids_on_serial_change(hass, entry, control)
+    # The platforms come up last, after every registry re-key: the slug-to-id
+    # hub migration at the end of start_central() and the serial reanchor above.
+    # Each therefore renames the entry that carries the history while nothing
+    # holds the new key, instead of resolving a collision against a twin that
+    # spawned seconds earlier — which left the historied entry without a live
+    # entity until the next restart.
+    await hass.config_entries.async_forward_entry_setups(entry, HMIP_LOCAL_PLATFORMS)
+    # The central reached its running state before any entity existed, so the
+    # standalone hub entities that key availability on it (the backup button)
+    # have no data point to refresh on and saw no transition. Tell them now.
+    control.async_signal_central_state_changed()
     await async_setup_services(hass)
 
     # Register WebSocket commands once (HA raises on duplicate registration)

--- a/custom_components/homematicip_local/control_unit.py
+++ b/custom_components/homematicip_local/control_unit.py
@@ -616,7 +616,8 @@ class ControlUnit(BaseControlUnit):
         }
         hub_coordinator = self._central.hub_coordinator
         # Programs + sysvars
-        current_unique_ids.update(f"{DOMAIN}_{dp.unique_id}" for dp in hub_coordinator.get_hub_data_points())
+        hub_data_points = hub_coordinator.get_hub_data_points()
+        current_unique_ids.update(f"{DOMAIN}_{dp.unique_id}" for dp in hub_data_points)
         # Singleton hub data points (alarm/service messages, inbox, system update)
         for single_dp in (
             hub_coordinator.alarm_messages_dp,
@@ -646,6 +647,19 @@ class ControlUnit(BaseControlUnit):
                 f"{DOMAIN}_{eg.unique_id}" for eg in self._central.query_facade.get_event_groups(event_type=event_type)
             )
 
+        # The pre-id keys the slug-to-id migration would rename onto one of the
+        # live data points above. It runs at the end of start_central(), so an
+        # entry still holding one here means it did not: it raised, or that data
+        # point yielded no old key. Deletion is permanent and the next start
+        # retries the migration, so these are kept rather than swept — the same
+        # reasoning as the central-id drift exemption below.
+        migratable_unique_ids: set[str] = {
+            f"{DOMAIN}_{old_unique_id}"
+            for dp in hub_data_points
+            if (legacy_name := getattr(dp, "legacy_name", None))
+            and (old_unique_id := hub_key_from_name_slug(dp.unique_id, legacy_name=legacy_name)) is not None
+        }
+
         entity_registry = er.async_get(self._hass)
         device_registry = dr.async_get(self._hass)
         platform_entries: list[er.RegistryEntry] = [
@@ -670,6 +684,7 @@ class ControlUnit(BaseControlUnit):
             if _is_orphan_registry_entry(
                 entry,
                 current_unique_ids=current_unique_ids,
+                migratable_unique_ids=migratable_unique_ids,
                 known_device_addresses=known_device_addresses,
                 device_registry=device_registry,
                 central_id=central_id,
@@ -1743,12 +1758,18 @@ def _is_orphan_registry_entry(
     entry: er.RegistryEntry,
     *,
     current_unique_ids: set[str],
+    migratable_unique_ids: set[str],
     known_device_addresses: set[str],
     device_registry: dr.DeviceRegistry,
     central_id: str,
 ) -> bool:
     """Return True only for entries whose data point is genuinely gone."""
     if entry.unique_id in current_unique_ids:
+        return False
+    # Pre-id hub key whose data point is right there under its id key: the
+    # slug-to-id migration has not taken it yet. The entry carries the history
+    # and the migration is retried on every start, so never sweep it.
+    if entry.unique_id in migratable_unique_ids:
         return False
     # The per-central backup button is integration-native (not an aiohomematic
     # routing key) and is recreated on every setup, so it must never be swept.

--- a/custom_components/homematicip_local/control_unit.py
+++ b/custom_components/homematicip_local/control_unit.py
@@ -358,6 +358,17 @@ class ControlUnit(BaseControlUnit):
         )
         self._orphan_cleanup_unsub: CALLBACK_TYPE | None = None
 
+    @callback
+    def async_signal_central_state_changed(self) -> None:
+        """Fan out that the central's availability may have changed.
+
+        Standalone hub entities that have no data point of their own — the
+        backup button — key their availability directly on ``central.available``
+        and cannot subscribe to a per-data-point refresh. They connect to this
+        dispatcher signal instead and re-render on it.
+        """
+        async_dispatcher_send(self._hass, signal_central_state_changed(entry_id=self._entry_id))
+
     def ensure_via_device_exists(
         self,
         *,
@@ -482,12 +493,11 @@ class ControlUnit(BaseControlUnit):
         )
         self._async_add_central_to_device_registry()
         await super().start_central()
-        # The central is available now. Standalone hub entities that key their
-        # availability on it (the backup button) are added before this runs,
-        # have no data point to refresh on and do not poll — so tell them to
-        # re-evaluate. The loom backend in particular reaches its running state
-        # without emitting a state event, so nothing else would.
-        self._async_signal_central_state_changed()
+        # Hub data is loaded now — `init_hub()` fetches programs and sysvars
+        # inside `start_clients()`, awaited — and no platform has been forwarded
+        # yet, so no entity holds the id-based keys. That is the one window in
+        # which re-keying the historied registry entries is a plain rename.
+        self._async_migrate_hub_keys_from_name_slug()
         if self._enable_mqtt:
             self._mqtt_consumer = MQTTConsumer(hass=self._hass, central=self._central, mqtt_prefix=self._mqtt_prefix)
             await self._mqtt_consumer.subscribe()
@@ -718,20 +728,33 @@ class ControlUnit(BaseControlUnit):
         bar the daemon's ADR 0068 sets for a re-key on this plane, and it is
         what makes this pass possible without a contract field.
 
-        Deferred with the orphan cleanup because it needs loaded hub data, which
-        means the freshly-keyed twins already exist. A collision is therefore
-        expected and resolved rather than skipped: the twin was created seconds
-        ago and holds nothing, the registry entry holds the history, so the twin
-        is removed and the historied entry takes the key. The other passes skip
-        on collision because they run before any entity exists, where a
-        collision means something genuinely unexpected.
+        Runs at the end of ``start_central()``: the hub fetch is complete
+        (``init_hub()`` awaits ``fetch_program_data`` / ``fetch_sysvar_data``
+        inside ``start_clients()``), so the live data points that carry the new
+        key exist — while the platforms have not been forwarded yet, so no
+        entity holds it. That makes this a plain rename of the entry that
+        carries the history, in the same position as every other re-key pass.
+
+        It used to run 60 s after the start, attached to the orphan cleanup on
+        the grounds that it needed loaded hub data. It does, but that data is
+        awaited during the start; the 60 s exist for ``system_update`` alone,
+        which this pass never touches.
+
+        The collision branch below is the repair path for a registry left
+        half-migrated by that deferred version, where the twin was spawned
+        before the rename and both keys can be present. The twin holds nothing
+        and the historied entry holds the history, so the twin is removed and
+        the historied entry takes the key.
 
         Idempotent: a second run finds no slug-keyed entries and does nothing.
         """
         try:
             hub_data_points = self._central.hub_coordinator.get_hub_data_points()
         except Exception:
-            _LOGGER.debug("Skipping hub key migration: hub data points unavailable", exc_info=True)
+            # Warning, not debug: the entities then spawn on the id keys while
+            # the historied slug-keyed entries stay behind, and on the
+            # aiohomematic backend the orphan sweep removes those 60 s later.
+            _LOGGER.warning("Skipping hub key migration: hub data points unavailable", exc_info=True)
             return
 
         # old registry unique_id -> current unique_id, for the two renameable
@@ -760,7 +783,7 @@ class ControlUnit(BaseControlUnit):
                 if twin_entity_id == entity_entry.entity_id:
                     continue
                 _LOGGER.debug(
-                    "Removing the freshly created twin so the historied entry can take its key: %s",
+                    "Removing the leftover twin so the historied entry can take its key: %s",
                     twin_entity_id,
                 )
                 entity_registry.async_remove(twin_entity_id)
@@ -777,23 +800,9 @@ class ControlUnit(BaseControlUnit):
 
     @callback
     def _async_scheduled_orphan_cleanup(self, _now: datetime) -> None:
-        """Run the deferred hub key migration, then the orphan cleanup."""
+        """Run the deferred orphan cleanup."""
         self._orphan_cleanup_unsub = None
-        # Order matters and is not incidental: the migration reclaims registry
-        # entries the cleanup would otherwise consider orphaned and delete.
-        self._async_migrate_hub_keys_from_name_slug()
         self._async_cleanup_orphaned_entity_registry_entries()
-
-    @callback
-    def _async_signal_central_state_changed(self) -> None:
-        """Fan out that the central's availability may have changed.
-
-        Standalone hub entities that have no data point of their own — the
-        backup button — key their availability directly on ``central.available``
-        and cannot subscribe to a per-data-point refresh. They connect to this
-        dispatcher signal instead and re-render on it.
-        """
-        async_dispatcher_send(self._hass, signal_central_state_changed(entry_id=self._entry_id))
 
     @callback
     def _cleanup_callback_issues(self) -> None:
@@ -1102,7 +1111,7 @@ class ControlUnit(BaseControlUnit):
         """Handle central state transitions."""
         # Every transition can flip central.available, so re-notify availability
         # dependent standalone entities regardless of the specific target state.
-        self._async_signal_central_state_changed()
+        self.async_signal_central_state_changed()
         if event.new_state == CentralState.RECOVERING:
             await self._on_central_recovering()
         elif event.new_state == CentralState.RUNNING:

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -73,7 +73,7 @@ class TestBackupButtonAvailability:
 
         # The central reaches its running state and the control unit announces it.
         control_unit._central.available = True
-        control_unit._async_signal_central_state_changed()
+        control_unit.async_signal_central_state_changed()
         await hass.async_block_till_done()
 
         button.async_write_ha_state.assert_called()
@@ -107,42 +107,44 @@ class TestCentralStateSignalWiring:
     """The control unit is the production caller of the central-state signal."""
 
     def test_notify_dispatches_on_the_signal(self, hass: HomeAssistant) -> None:
-        """_async_signal_central_state_changed sends the entry-scoped signal."""
+        """async_signal_central_state_changed sends the entry-scoped signal."""
         control_unit = _make_control_unit(hass, entry_id="e1")
         with patch("custom_components.homematicip_local.control_unit.async_dispatcher_send") as send:
-            control_unit._async_signal_central_state_changed()
+            control_unit.async_signal_central_state_changed()
         send.assert_called_once_with(hass, signal_central_state_changed(entry_id="e1"))
 
     async def test_runtime_state_transition_signals(self, hass: HomeAssistant) -> None:
         """Every central-state transition re-announces the change."""
         control_unit = _make_control_unit(hass, entry_id="e1")
         control_unit._instance_name = "X"
-        control_unit._async_signal_central_state_changed = Mock()
+        control_unit.async_signal_central_state_changed = Mock()
         event = SimpleNamespace(new_state=CentralState.RUNNING)
 
         with patch.object(ControlUnit, "_on_central_running", new=AsyncMock()):
             await control_unit._on_central_state_changed(event=event)
 
-        control_unit._async_signal_central_state_changed.assert_called_once()
+        control_unit.async_signal_central_state_changed.assert_called_once()
 
     def test_signal_is_entry_scoped(self) -> None:
         """The signal name is scoped to the config entry, so entries don't cross-talk."""
         assert signal_central_state_changed(entry_id="a") != signal_central_state_changed(entry_id="b")
 
-    async def test_start_central_signals_after_start(self, hass: HomeAssistant) -> None:
+    async def test_start_central_leaves_the_signal_to_setup(self, hass: HomeAssistant) -> None:
         """
-        start_central announces the central-state change once the central is up.
+        start_central no longer signals — no entity exists yet to hear it.
 
-        Without this the loom backend — which reaches its running state without
-        emitting a state event — would never notify the backup button, leaving it
-        unavailable forever.
+        It runs before the platforms are forwarded so the hub key migration can
+        re-key the registry while nothing holds the new keys. The announcement
+        the backup button needs therefore moved to `async_setup_entry`, after
+        the forward; `TestSetupOrdering` in test_init.py pins that position.
         """
         control_unit = _make_control_unit(hass, entry_id="e1")
         control_unit._instance_name = "X"
         control_unit._subscription_group = MagicMock()
         control_unit._enable_mqtt = False
         control_unit._orphan_cleanup_unsub = None
-        control_unit._async_signal_central_state_changed = Mock()
+        control_unit.async_signal_central_state_changed = Mock()
+        control_unit._async_migrate_hub_keys_from_name_slug = Mock()
 
         with (
             patch.object(ControlUnit, "_cleanup_callback_issues"),
@@ -152,4 +154,5 @@ class TestCentralStateSignalWiring:
         ):
             await control_unit.start_central()
 
-        control_unit._async_signal_central_state_changed.assert_called_once()
+        control_unit.async_signal_central_state_changed.assert_not_called()
+        control_unit._async_migrate_hub_keys_from_name_slug.assert_called_once()

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import ast
+import pathlib
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -35,6 +37,66 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from tests import const
+
+
+def _call_line(func: ast.AsyncFunctionDef, attribute: str) -> int:
+    """Return the line of the sole call to ``attribute`` in ``func``, bare or attribute-style."""
+    lines = [
+        node.lineno
+        for node in ast.walk(func)
+        if isinstance(node, ast.Call)
+        and (
+            (isinstance(node.func, ast.Attribute) and node.func.attr == attribute)
+            or (isinstance(node.func, ast.Name) and node.func.id == attribute)
+        )
+    ]
+    assert len(lines) == 1, f"expected exactly one call to {attribute}, found {len(lines)}"
+    return lines[0]
+
+
+class TestSetupOrdering:
+    """Every registry re-key must land before an entity holds the new key.
+
+    ``start_central()`` runs the slug-to-id hub migration at its end, where the
+    hub data is loaded (``init_hub()`` awaits the program and sysvar fetches
+    inside ``start_clients()``) and no platform has been forwarded. Forward the
+    platforms first and a freshly spawned twin already holds the new key, so the
+    migration has to remove that twin — which detaches the live entity and
+    leaves the historied entry bound to nothing until the next restart. That was
+    the shipped behaviour and the reason an update needed two restarts.
+
+    The constraint is an ordering between two awaits with no observable a unit
+    test can reach without standing up the whole setup path, so it is read off
+    the source of ``async_setup_entry`` itself.
+    """
+
+    @staticmethod
+    def _setup_entry() -> ast.AsyncFunctionDef:
+        source = pathlib.Path(custom_components.homematicip_local.__file__).read_text(encoding="utf-8")
+        return next(
+            node
+            for node in ast.parse(source).body
+            if isinstance(node, ast.AsyncFunctionDef) and node.name == "async_setup_entry"
+        )
+
+    def test_platforms_are_forwarded_after_the_central_starts(self) -> None:
+        """The re-keys inside start_central() run while no entity exists."""
+        function = self._setup_entry()
+        assert _call_line(function, "start_central") < _call_line(function, "async_forward_entry_setups")
+
+    def test_the_central_state_signal_follows_the_platforms(self) -> None:
+        """The backup button can only hear the signal once it is on the bus."""
+        function = self._setup_entry()
+        assert _call_line(function, "async_forward_entry_setups") < _call_line(
+            function, "async_signal_central_state_changed"
+        )
+
+    def test_the_serial_reanchor_also_precedes_the_platforms(self) -> None:
+        """The other re-key pass on this path needs the same empty registry."""
+        function = self._setup_entry()
+        assert _call_line(function, "_async_reanchor_hub_unique_ids_on_serial_change") < _call_line(
+            function, "async_forward_entry_setups"
+        )
 
 
 class TestSetupEntry:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -39,6 +39,74 @@ from homeassistant.helpers import device_registry as dr, entity_registry as er
 from tests import const
 
 
+class TestSweepSparesUnmigratedHubKeys:
+    """A pre-id sysvar / program key is not an orphan while its data point is live.
+
+    The slug-to-id migration runs at the end of ``start_central()``, before any
+    entity exists. When it does not take — ``get_hub_data_points()`` raised, or
+    a data point yielded no old key — the historied entry keeps the slug, and
+    without this exemption the sweep 60 s later reads it as an orphan (no device
+    address, so ``_is_orphan_registry_entry`` falls through to ``True``) and
+    deletes it with its history, name and area. Keeping it costs one more start;
+    deleting it is permanent.
+    """
+
+    _SERIAL = "11a0001234"
+
+    @staticmethod
+    def _seed(hass: HomeAssistant, entry: MockConfigEntry, *, unique_id: str) -> er.RegistryEntry:
+        return er.async_get(hass).async_get_or_create(
+            domain="sensor",
+            platform=HMIP_DOMAIN,
+            unique_id=f"{HMIP_DOMAIN}_{unique_id}",
+            config_entry=entry,
+        )
+
+    async def test_a_slug_key_with_no_live_data_point_is_still_swept(
+        self, hass: HomeAssistant, mock_config_entry_v2: MockConfigEntry
+    ) -> None:
+        """The exemption is narrow: it spares only keys a live data point claims.
+
+        Negative control for the test above — without it, that one would pass
+        just as well if the sweep had stopped removing hub entries altogether.
+        """
+        mock_config_entry_v2.add_to_hass(hass)
+        alive = self._seed(hass, mock_config_entry_v2, unique_id="alive_dp")
+        gone = self._seed(hass, mock_config_entry_v2, unique_id=f"loom_{self._SERIAL}_sysvar_geloeschte-variable")
+
+        fake_self = _build_orphan_sweep_self(
+            hass,
+            mock_config_entry_v2.entry_id,
+            data_point_unique_ids=("alive_dp",),
+            named_hub_data_points=((f"loom_{self._SERIAL}_sysvar_12345", "Außen Temperatur"),),
+        )
+        ControlUnit._async_cleanup_orphaned_entity_registry_entries(fake_self)
+
+        entity_registry = er.async_get(hass)
+        assert entity_registry.async_get(alive.entity_id) is not None
+        assert entity_registry.async_get(gone.entity_id) is None
+
+    async def test_slug_keyed_entry_survives_while_its_data_point_is_live(
+        self, hass: HomeAssistant, mock_config_entry_v2: MockConfigEntry
+    ) -> None:
+        """The entry the migration has yet to rename is kept, not swept."""
+        mock_config_entry_v2.add_to_hass(hass)
+        alive = self._seed(hass, mock_config_entry_v2, unique_id="alive_dp")
+        unmigrated = self._seed(hass, mock_config_entry_v2, unique_id=f"loom_{self._SERIAL}_sysvar_aussen-temperatur")
+
+        fake_self = _build_orphan_sweep_self(
+            hass,
+            mock_config_entry_v2.entry_id,
+            data_point_unique_ids=("alive_dp",),
+            named_hub_data_points=((f"loom_{self._SERIAL}_sysvar_12345", "Außen Temperatur"),),
+        )
+        ControlUnit._async_cleanup_orphaned_entity_registry_entries(fake_self)
+
+        entity_registry = er.async_get(hass)
+        assert entity_registry.async_get(alive.entity_id) is not None
+        assert entity_registry.async_get(unmigrated.entity_id) is not None
+
+
 def _call_line(func: ast.AsyncFunctionDef, attribute: str) -> int:
     """Return the line of the sole call to ``attribute`` in ``func``, bare or attribute-style."""
     lines = [
@@ -334,6 +402,7 @@ def _build_orphan_sweep_self(
     state: CentralState = CentralState.RUNNING,
     data_point_unique_ids: tuple[str, ...] = (),
     hub_unique_ids: tuple[str, ...] = (),
+    named_hub_data_points: tuple[tuple[str, str], ...] = (),
     event_group_unique_ids: tuple[str, ...] = (),
     alarm_messages_unique_id: str | None = None,
     service_messages_unique_id: str | None = None,
@@ -355,7 +424,7 @@ def _build_orphan_sweep_self(
     )
     central.hub_coordinator.get_hub_data_points.return_value = tuple(
         SimpleNamespace(unique_id=uid) for uid in hub_unique_ids
-    )
+    ) + tuple(SimpleNamespace(unique_id=uid, legacy_name=legacy_name) for uid, legacy_name in named_hub_data_points)
     central.hub_coordinator.alarm_messages_dp = (
         SimpleNamespace(unique_id=alarm_messages_unique_id) if alarm_messages_unique_id else None
     )


### PR DESCRIPTION
## The bug

Updating to the version that ships the slug→id hub key migration needed **two** Home Assistant restarts before the sysvar and program entities came back.

The migration ran 60 s after the start, attached to the orphan cleanup, on the grounds that it "needs loaded hub data". By then the platforms had spawned entities on the id keys, so the migration met a twin: it removed the twin's registry entry (`async_remove`) and renamed the historied entry onto the freed key. The registry ended up correct — but the *live entity* was bound to the entry that had just been removed, and binding only happens at `async_add_entities`. The historied entry had no entity behind it until the next restart.

## Why it can run earlier

The stated obstacle does not hold. The hub data is **awaited during the start**, not fetched by the scheduler:

- aiohomematic: `central_unit.py:664` awaits `start_clients()` → `coordinators/client.py:283` awaits `init_hub()` → `coordinators/hub.py:468-469` awaits `fetch_program_data` / `fetch_sysvar_data`.
- openccu-loom: `adapter.py:1246` awaits `_bootstrap_model()` → `:1324-1325` awaits `_bootstrap_hub_catalogue()` and `fetch_hub_singleton_data()`.

This repository already said so, right above the constant (`control_unit.py:186-190`): programs and sysvars are populated by `init_hub()` during `start_clients()`; the 60 s exist for `system_update` alone — a family `hub_key_from_name_slug` never touches (it matches `_sysvar_` / `_program_` only).

And the platforms do not have to be set up first: `async_setup_entry` connects the dispatcher *and* enumerates with `registered=False` (`control_unit.py:424,437`), so it picks up everything the central already holds. `register()` is called by the consumer, so a signal fired with no listener does not flip the flag.

## Commit 1 — run the migration before the platforms

`start_central()` moves ahead of `async_forward_entry_setups`. Both re-key passes on this path — the hub migration at the end of `start_central()`, and `_async_reanchor_hub_unique_ids_on_serial_change` — then run with hub data loaded and no entity holding the new keys. The rename is plain, and the second restart is gone.

Carried along:

- `async_signal_central_state_changed` (now public) moves to after the forward. The central reaches its running state before any entity exists, so the announcement the backup button needs has to be made once it is on the bus.
- The migration's failure path logs at **warning**, not debug.
- The collision branch stays, now solely as the repair path for a registry the deferred version left half-migrated.

## Commit 2 — stop the sweep eating what the migration did not take

The migration can still decline: `get_hub_data_points()` raises, or a data point yields no old key. The historied entry then keeps its slug, and `_is_orphan_registry_entry` classifies it as an orphan — a hub entry has no device address, so the function falls through to `return True` (`control_unit.py:1733-1762`) — and the sweep deletes it with its history, name and area. `ORPHAN_CLEANUP_MAX_DELETE_RATIO = 0.5` does not trip, because sysvars and programs are a small share of a device-heavy registry.

The sweep now rebuilds the pre-id key for every live hub data point and keeps any entry still holding one — symmetric to the `realign_hub_unique_id` exemption beside it. The next start retries the migration; deletion has no next start.

Only the aiohomematic backend reaches this code (the sweep returns early on loom), but the guard is backend-agnostic.

## Tests

- `TestSetupOrdering` pins the three positions off the source of `async_setup_entry` — the constraint is an ordering between two awaits with no observable a unit test can reach without standing up the whole setup path.
- `TestSweepSparesUnmigratedHubKeys` covers the exemption. The positive test was **verified to fail without it**, with the sweep removing the seeded entry; the negative control pins that a slug key no live data point claims is still swept.
- `test_start_central_leaves_the_signal_to_setup` replaces the test that asserted the old signal position, and additionally pins that `start_central()` runs the migration.
- Full suite: 955 passed, 8 skipped. The entity tests set up through `hass.config_entries.async_setup`, so they exercise the reordered path for real.