### PR TITLE
fix(init): restore the hub entities #1275 stopped spawning

### DIFF
--- a/custom_components/homematicip_local/__init__.py
+++ b/custom_components/homematicip_local/__init__.py
@@ -242,6 +242,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: HomematicConfigEntry) ->
         default_callback_port_xml_rpc=default_callback_port_xml_rpc,
     ).create_control_unit()
     entry.runtime_data = control
+    await hass.config_entries.async_forward_entry_setups(entry, HMIP_LOCAL_PLATFORMS)
     try:
         await control.start_central()
     except AuthFailure as err:
@@ -267,17 +268,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: HomematicConfigEntry) ->
         raise ConfigEntryError(str(err)) from err
     if not is_loom_backend:
         await _async_reanchor_hub_unique_ids_on_serial_change(hass, entry, control)
-    # The platforms come up last, after every registry re-key: the slug-to-id
-    # hub migration at the end of start_central() and the serial reanchor above.
-    # Each therefore renames the entry that carries the history while nothing
-    # holds the new key, instead of resolving a collision against a twin that
-    # spawned seconds earlier — which left the historied entry without a live
-    # entity until the next restart.
-    await hass.config_entries.async_forward_entry_setups(entry, HMIP_LOCAL_PLATFORMS)
-    # The central reached its running state before any entity existed, so the
-    # standalone hub entities that key availability on it (the backup button)
-    # have no data point to refresh on and saw no transition. Tell them now.
-    control.async_signal_central_state_changed()
     await async_setup_services(hass)
 
     # Register WebSocket commands once (HA raises on duplicate registration)

--- a/custom_components/homematicip_local/control_unit.py
+++ b/custom_components/homematicip_local/control_unit.py
@@ -190,6 +190,13 @@ def hub_key_from_name_slug(unique_id: str, *, legacy_name: str) -> str | None:
 # comfortably covers the first scheduler iteration of fetch_system_update_data.
 ORPHAN_CLEANUP_DELAY: Final = 60
 
+# Config entries whose hub key migration has already asked for its one reload,
+# kept in hass.data so it survives that reload. The pass is idempotent, so a
+# second run finds nothing to migrate and asks for nothing — but that is an
+# argument about the pass, and an automatic reload loop is a bad enough failure
+# to close by construction instead.
+HUB_KEY_RELOAD_SCHEDULED: Final = f"{DOMAIN}_hub_key_reload_scheduled"
+
 # Safety threshold for the orphan entity registry cleanup. The central reports
 # RUNNING as soon as all clients are connected, which does not guarantee that the
 # device descriptions were actually loaded (e.g. a transient auth error during a
@@ -788,20 +795,30 @@ class ControlUnit(BaseControlUnit):
             entity_registry.async_update_entity(entity_entry.entity_id, new_unique_id=new_unique_id)
             migrated += 1
 
-        if migrated:
-            _LOGGER.info(
-                "Migrated %s hub entity registry key(s) onto the CCU id; reloading so the entities re-bind",
+        if not migrated:
+            return
+
+        # The renamed entry holds the history but nothing live: the entity that
+        # existed a moment ago was bound to the twin, and removing the twin
+        # removed it. Binding happens at `async_add_entities`, which is over for
+        # this session, so without a reload the entity stays gone until the user
+        # restarts — which is what an update used to cost.
+        already_reloaded: set[str] = self._hass.data.setdefault(HUB_KEY_RELOAD_SCHEDULED, set())
+        if self._entry_id in already_reloaded:
+            # Reaching here twice means the pass did not converge, so reloading
+            # again would not either. Say so and leave it to the next restart.
+            _LOGGER.warning(
+                "Migrated %s hub entity registry key(s) onto the CCU id after a reload already ran; "
+                "not reloading again — those entities re-bind on the next restart",
                 migrated,
             )
-            # The renamed entry holds the history but nothing live: the entity
-            # that existed a moment ago was bound to the twin, and removing the
-            # twin removed it. Binding happens at `async_add_entities`, which is
-            # over for this session, so without a reload the entity stays gone
-            # until the user restarts — which is what an update used to cost.
-            #
-            # Runs exactly once. The next setup finds every key already on the
-            # id, migrates nothing, and schedules nothing.
-            self._hass.config_entries.async_schedule_reload(self._entry_id)
+            return
+        already_reloaded.add(self._entry_id)
+        _LOGGER.info(
+            "Migrated %s hub entity registry key(s) onto the CCU id; reloading so the entities re-bind",
+            migrated,
+        )
+        self._hass.config_entries.async_schedule_reload(self._entry_id)
 
     @callback
     def _async_scheduled_orphan_cleanup(self, _now: datetime) -> None:

--- a/custom_components/homematicip_local/control_unit.py
+++ b/custom_components/homematicip_local/control_unit.py
@@ -358,17 +358,6 @@ class ControlUnit(BaseControlUnit):
         )
         self._orphan_cleanup_unsub: CALLBACK_TYPE | None = None
 
-    @callback
-    def async_signal_central_state_changed(self) -> None:
-        """Fan out that the central's availability may have changed.
-
-        Standalone hub entities that have no data point of their own — the
-        backup button — key their availability directly on ``central.available``
-        and cannot subscribe to a per-data-point refresh. They connect to this
-        dispatcher signal instead and re-render on it.
-        """
-        async_dispatcher_send(self._hass, signal_central_state_changed(entry_id=self._entry_id))
-
     def ensure_via_device_exists(
         self,
         *,
@@ -493,11 +482,12 @@ class ControlUnit(BaseControlUnit):
         )
         self._async_add_central_to_device_registry()
         await super().start_central()
-        # Hub data is loaded now — `init_hub()` fetches programs and sysvars
-        # inside `start_clients()`, awaited — and no platform has been forwarded
-        # yet, so no entity holds the id-based keys. That is the one window in
-        # which re-keying the historied registry entries is a plain rename.
-        self._async_migrate_hub_keys_from_name_slug()
+        # The central is available now. Standalone hub entities that key their
+        # availability on it (the backup button) are added before this runs,
+        # have no data point to refresh on and do not poll — so tell them to
+        # re-evaluate. The loom backend in particular reaches its running state
+        # without emitting a state event, so nothing else would.
+        self._async_signal_central_state_changed()
         if self._enable_mqtt:
             self._mqtt_consumer = MQTTConsumer(hass=self._hass, central=self._central, mqtt_prefix=self._mqtt_prefix)
             await self._mqtt_consumer.subscribe()
@@ -743,33 +733,21 @@ class ControlUnit(BaseControlUnit):
         bar the daemon's ADR 0068 sets for a re-key on this plane, and it is
         what makes this pass possible without a contract field.
 
-        Runs at the end of ``start_central()``: the hub fetch is complete
-        (``init_hub()`` awaits ``fetch_program_data`` / ``fetch_sysvar_data``
-        inside ``start_clients()``), so the live data points that carry the new
-        key exist — while the platforms have not been forwarded yet, so no
-        entity holds it. That makes this a plain rename of the entry that
-        carries the history, in the same position as every other re-key pass.
+        Deferred with the orphan cleanup because it needs loaded hub data, which
+        means the freshly-keyed twins already exist. A collision is therefore
+        expected and resolved rather than skipped: the twin was created seconds
+        ago and holds nothing, the registry entry holds the history, so the twin
+        is removed and the historied entry takes the key. The other passes skip
+        on collision because they run before any entity exists, where a
+        collision means something genuinely unexpected.
 
-        It used to run 60 s after the start, attached to the orphan cleanup on
-        the grounds that it needed loaded hub data. It does, but that data is
-        awaited during the start; the 60 s exist for ``system_update`` alone,
-        which this pass never touches.
-
-        The collision branch below is the repair path for a registry left
-        half-migrated by that deferred version, where the twin was spawned
-        before the rename and both keys can be present. The twin holds nothing
-        and the historied entry holds the history, so the twin is removed and
-        the historied entry takes the key.
-
-        Idempotent: a second run finds no slug-keyed entries and does nothing.
+        Idempotent: a second run finds no slug-keyed entries and does nothing,
+        which is also what stops the reload below from repeating.
         """
         try:
             hub_data_points = self._central.hub_coordinator.get_hub_data_points()
         except Exception:
-            # Warning, not debug: the entities then spawn on the id keys while
-            # the historied slug-keyed entries stay behind, and on the
-            # aiohomematic backend the orphan sweep removes those 60 s later.
-            _LOGGER.warning("Skipping hub key migration: hub data points unavailable", exc_info=True)
+            _LOGGER.debug("Skipping hub key migration: hub data points unavailable", exc_info=True)
             return
 
         # old registry unique_id -> current unique_id, for the two renameable
@@ -798,7 +776,7 @@ class ControlUnit(BaseControlUnit):
                 if twin_entity_id == entity_entry.entity_id:
                     continue
                 _LOGGER.debug(
-                    "Removing the leftover twin so the historied entry can take its key: %s",
+                    "Removing the freshly created twin so the historied entry can take its key: %s",
                     twin_entity_id,
                 )
                 entity_registry.async_remove(twin_entity_id)
@@ -811,13 +789,39 @@ class ControlUnit(BaseControlUnit):
             migrated += 1
 
         if migrated:
-            _LOGGER.info("Migrated %s hub entity registry key(s) onto the CCU id", migrated)
+            _LOGGER.info(
+                "Migrated %s hub entity registry key(s) onto the CCU id; reloading so the entities re-bind",
+                migrated,
+            )
+            # The renamed entry holds the history but nothing live: the entity
+            # that existed a moment ago was bound to the twin, and removing the
+            # twin removed it. Binding happens at `async_add_entities`, which is
+            # over for this session, so without a reload the entity stays gone
+            # until the user restarts — which is what an update used to cost.
+            #
+            # Runs exactly once. The next setup finds every key already on the
+            # id, migrates nothing, and schedules nothing.
+            self._hass.config_entries.async_schedule_reload(self._entry_id)
 
     @callback
     def _async_scheduled_orphan_cleanup(self, _now: datetime) -> None:
-        """Run the deferred orphan cleanup."""
+        """Run the deferred hub key migration, then the orphan cleanup."""
         self._orphan_cleanup_unsub = None
+        # Order matters and is not incidental: the migration reclaims registry
+        # entries the cleanup would otherwise consider orphaned and delete.
+        self._async_migrate_hub_keys_from_name_slug()
         self._async_cleanup_orphaned_entity_registry_entries()
+
+    @callback
+    def _async_signal_central_state_changed(self) -> None:
+        """Fan out that the central's availability may have changed.
+
+        Standalone hub entities that have no data point of their own — the
+        backup button — key their availability directly on ``central.available``
+        and cannot subscribe to a per-data-point refresh. They connect to this
+        dispatcher signal instead and re-render on it.
+        """
+        async_dispatcher_send(self._hass, signal_central_state_changed(entry_id=self._entry_id))
 
     @callback
     def _cleanup_callback_issues(self) -> None:
@@ -1126,7 +1130,7 @@ class ControlUnit(BaseControlUnit):
         """Handle central state transitions."""
         # Every transition can flip central.available, so re-notify availability
         # dependent standalone entities regardless of the specific target state.
-        self.async_signal_central_state_changed()
+        self._async_signal_central_state_changed()
         if event.new_state == CentralState.RECOVERING:
             await self._on_central_recovering()
         elif event.new_state == CentralState.RUNNING:

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -65,6 +65,7 @@ class Factory:
         address_device_translation: dict[str, str],
         ignore_devices_on_create: list[str] | None = None,
         un_ignore_list: list[str] | None = None,
+        start_central_before_setup: bool = True,
     ) -> tuple[HomeAssistant, ControlUnit]:
         """Return a central based on give address_device_translation."""
         central = await self._backend_factory.init(
@@ -81,8 +82,16 @@ class Factory:
         central.event_bus.subscribe(
             event_type=RpcParameterReceivedEvent, event_key=None, handler=self.entity_event_mock
         )
-        await central.start()
-        await central.hub_coordinator.init_hub()
+        # Production starts the central from `ControlUnit.start_central()`, which
+        # runs after the platforms are forwarded. Starting it here instead is
+        # convenient — the serial is known before the entry is set up, so the
+        # re-anchor below stays quiet — but it means every data point announced
+        # during the start is announced to nobody, and only the ones a platform
+        # enumerates at setup ever become entities. `start_central_before_setup`
+        # off reproduces the production order for the tests that need it.
+        if start_central_before_setup:
+            await central.start()
+            await central.hub_coordinator.init_hub()
 
         patch("custom_components.homematicip_local.find_free_port", return_value=8765).start()
         patch(

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -73,7 +73,7 @@ class TestBackupButtonAvailability:
 
         # The central reaches its running state and the control unit announces it.
         control_unit._central.available = True
-        control_unit.async_signal_central_state_changed()
+        control_unit._async_signal_central_state_changed()
         await hass.async_block_till_done()
 
         button.async_write_ha_state.assert_called()
@@ -107,44 +107,42 @@ class TestCentralStateSignalWiring:
     """The control unit is the production caller of the central-state signal."""
 
     def test_notify_dispatches_on_the_signal(self, hass: HomeAssistant) -> None:
-        """async_signal_central_state_changed sends the entry-scoped signal."""
+        """_async_signal_central_state_changed sends the entry-scoped signal."""
         control_unit = _make_control_unit(hass, entry_id="e1")
         with patch("custom_components.homematicip_local.control_unit.async_dispatcher_send") as send:
-            control_unit.async_signal_central_state_changed()
+            control_unit._async_signal_central_state_changed()
         send.assert_called_once_with(hass, signal_central_state_changed(entry_id="e1"))
 
     async def test_runtime_state_transition_signals(self, hass: HomeAssistant) -> None:
         """Every central-state transition re-announces the change."""
         control_unit = _make_control_unit(hass, entry_id="e1")
         control_unit._instance_name = "X"
-        control_unit.async_signal_central_state_changed = Mock()
+        control_unit._async_signal_central_state_changed = Mock()
         event = SimpleNamespace(new_state=CentralState.RUNNING)
 
         with patch.object(ControlUnit, "_on_central_running", new=AsyncMock()):
             await control_unit._on_central_state_changed(event=event)
 
-        control_unit.async_signal_central_state_changed.assert_called_once()
+        control_unit._async_signal_central_state_changed.assert_called_once()
 
     def test_signal_is_entry_scoped(self) -> None:
         """The signal name is scoped to the config entry, so entries don't cross-talk."""
         assert signal_central_state_changed(entry_id="a") != signal_central_state_changed(entry_id="b")
 
-    async def test_start_central_leaves_the_signal_to_setup(self, hass: HomeAssistant) -> None:
+    async def test_start_central_signals_after_start(self, hass: HomeAssistant) -> None:
         """
-        start_central no longer signals — no entity exists yet to hear it.
+        start_central announces the central-state change once the central is up.
 
-        It runs before the platforms are forwarded so the hub key migration can
-        re-key the registry while nothing holds the new keys. The announcement
-        the backup button needs therefore moved to `async_setup_entry`, after
-        the forward; `TestSetupOrdering` in test_init.py pins that position.
+        Without this the loom backend — which reaches its running state without
+        emitting a state event — would never notify the backup button, leaving it
+        unavailable forever.
         """
         control_unit = _make_control_unit(hass, entry_id="e1")
         control_unit._instance_name = "X"
         control_unit._subscription_group = MagicMock()
         control_unit._enable_mqtt = False
         control_unit._orphan_cleanup_unsub = None
-        control_unit.async_signal_central_state_changed = Mock()
-        control_unit._async_migrate_hub_keys_from_name_slug = Mock()
+        control_unit._async_signal_central_state_changed = Mock()
 
         with (
             patch.object(ControlUnit, "_cleanup_callback_issues"),
@@ -154,5 +152,4 @@ class TestCentralStateSignalWiring:
         ):
             await control_unit.start_central()
 
-        control_unit.async_signal_central_state_changed.assert_not_called()
-        control_unit._async_migrate_hub_keys_from_name_slug.assert_called_once()
+        control_unit._async_signal_central_state_changed.assert_called_once()

--- a/tests/test_hub_singletons.py
+++ b/tests/test_hub_singletons.py
@@ -1,0 +1,107 @@
+"""The hub singletons reach Home Assistant by announcement, not by enumeration."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from custom_components.homematicip_local.const import DOMAIN as HMIP_DOMAIN
+from custom_components.homematicip_local.control_unit import ControlUnit
+from homeassistant.helpers import entity_registry as er
+
+from tests import helper
+
+TEST_DEVICES: dict[str, str] = {"VCU2128127": "HmIP-BSM"}
+
+
+def _singleton_unique_ids(control: ControlUnit) -> dict[str, str]:
+    """Return ``{label: registry unique_id}`` for every hub singleton the coordinator holds.
+
+    Read off the coordinator rather than hard-coded, so a singleton added later
+    is covered the day it appears instead of the day someone remembers to list
+    it here.
+    """
+    hub_coordinator = control.central.hub_coordinator
+    found: dict[str, str] = {}
+    for label in ("alarm_messages_dp", "service_messages_dp", "inbox_dp", "update_dp"):
+        if (data_point := getattr(hub_coordinator, label, None)) is not None:
+            found[label] = f"{HMIP_DOMAIN}_{data_point.unique_id}"
+    if (metrics := hub_coordinator.metrics_dps) is not None:
+        for label in ("system_health", "connection_latency", "last_event_age"):
+            found[label] = f"{HMIP_DOMAIN}_{getattr(metrics, label).unique_id}"
+    for interface_id, connectivity in hub_coordinator.connectivity_dps.items():
+        found[f"connectivity:{interface_id}"] = f"{HMIP_DOMAIN}_{connectivity.sensor.unique_id}"
+    for interface, install_mode in hub_coordinator.install_mode_dps.items():
+        found[f"install_mode_button:{interface}"] = f"{HMIP_DOMAIN}_{install_mode.button.unique_id}"
+        found[f"install_mode_sensor:{interface}"] = f"{HMIP_DOMAIN}_{install_mode.sensor.unique_id}"
+    return found
+
+
+class TestHubSingletonsBecomeEntities:
+    """The gap that let #1275 drop every announced entity while the suite stayed green.
+
+    `hub_coordinator.get_hub_data_points()` returns programs and sysvars only
+    (`aiohomematic/central/coordinators/hub.py:380-384`), and that is the only
+    hub query the platforms enumerate in their setup tails. The metrics,
+    connectivity and install-mode data points arrive solely through
+    `DataPointsCreatedEvent` → `signal_new_data_point`
+    (`aiohomematic/central/coordinators/event.py:524-537`), so they become
+    entities only if the platforms are already listening when the central
+    starts — which in production they are, because `start_central()` runs after
+    `async_forward_entry_setups`.
+
+    The default test harness starts the central *before* setting the entry up,
+    which is exactly the ordering that loses them. So these entities never
+    existed in any test, and a change that stopped them existing in production
+    could not fail anything. `start_central_before_setup=False` puts the
+    harness in the production order; without it the first test below fails on
+    every singleton.
+    """
+
+    async def test_every_singleton_the_coordinator_holds_has_a_registry_entry(
+        self, factory_ccu: helper.Factory
+    ) -> None:
+        """Announced entities exist when the platforms are up before the central starts."""
+        with patch("custom_components.homematicip_local._async_reanchor_hub_unique_ids_on_serial_change"):
+            # Patched, not worked around: the harness cannot know the CCU serial
+            # before the central runs, so the entry's unique_id is still the
+            # placeholder when setup begins and the re-anchor would re-key
+            # everything and reload mid-test. It is covered on its own elsewhere
+            # and has nothing to do with what this asserts.
+            hass, control = await factory_ccu.setup_environment(TEST_DEVICES, start_central_before_setup=False)
+
+        expected = _singleton_unique_ids(control)
+        assert expected, "the coordinator holds no singletons — this asserts nothing"
+
+        entity_registry = er.async_get(hass)
+        present = {
+            entry.unique_id
+            for entry in er.async_entries_for_config_entry(entity_registry, factory_ccu.mock_config_entry.entry_id)
+        }
+        missing = {label: unique_id for label, unique_id in expected.items() if unique_id not in present}
+        assert missing == {}, (
+            "hub singletons the coordinator holds never became entities — they are announced, "
+            f"not enumerated, so the platforms were not listening when the central started: {missing}"
+        )
+
+    async def test_the_default_harness_order_is_the_one_that_loses_them(self, factory_ccu: helper.Factory) -> None:
+        """Pin why the suite was blind, so nobody 'fixes' the flag away.
+
+        Negative control for the test above: with the central started before the
+        entry, the very same singletons are absent. That is the harness being
+        unlike production, not a product defect — and it is the reason the
+        first test has to ask for the other order.
+        """
+        hass, control = await factory_ccu.setup_environment(TEST_DEVICES)
+
+        expected = _singleton_unique_ids(control)
+        assert expected, "the coordinator holds no singletons — this asserts nothing"
+
+        entity_registry = er.async_get(hass)
+        present = {
+            entry.unique_id
+            for entry in er.async_entries_for_config_entry(entity_registry, factory_ccu.mock_config_entry.entry_id)
+        }
+        assert not (set(expected.values()) & present), (
+            "the default harness order now spawns singletons too — if that is intended, "
+            "the first test no longer needs start_central_before_setup=False"
+        )

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1517,6 +1517,60 @@ class TestHubKeyMigrationAgainstTheRegistry:
         # schedules nothing, so this cannot become a loop.
         scheduled_reload.assert_called_once_with(mock_config_entry_v2.entry_id)
 
+    async def test_a_later_migrating_pass_does_not_reload_again(
+        self, hass: HomeAssistant, mock_config_entry_v2: MockConfigEntry, scheduled_reload: MagicMock
+    ) -> None:
+        """A pass that migrates after the reload already ran asks for nothing.
+
+        Idempotency makes a second migrating pass unreachable in theory, which
+        is exactly why this is pinned by construction: if it ever were reached,
+        reloading on every one of them would put the config entry in a loop.
+        """
+        mock_config_entry_v2.add_to_hass(hass)
+        self._seed(
+            hass,
+            mock_config_entry_v2,
+            unique_id=f"loom_{self._SERIAL}_sysvar_aussen-temperatur",
+            entity_suffix="aussen_temperatur",
+        )
+        ControlUnit._async_migrate_hub_keys_from_name_slug(
+            _build_hub_migration_self(
+                hass,
+                mock_config_entry_v2.entry_id,
+                hub_data_points=(
+                    SimpleNamespace(unique_id=f"loom_{self._SERIAL}_sysvar_12345", legacy_name="Außen Temperatur"),
+                ),
+            )
+        )
+        scheduled_reload.assert_called_once_with(mock_config_entry_v2.entry_id)
+
+        # A second, genuinely migrating pass — a different variable this time.
+        self._seed(
+            hass,
+            mock_config_entry_v2,
+            unique_id=f"loom_{self._SERIAL}_sysvar_luftfeuchte",
+            entity_suffix="luftfeuchte",
+        )
+        ControlUnit._async_migrate_hub_keys_from_name_slug(
+            _build_hub_migration_self(
+                hass,
+                mock_config_entry_v2.entry_id,
+                hub_data_points=(
+                    SimpleNamespace(unique_id=f"loom_{self._SERIAL}_sysvar_67890", legacy_name="Luftfeuchte"),
+                ),
+            )
+        )
+
+        entity_registry = er.async_get(hass)
+        assert {
+            entry.unique_id
+            for entry in er.async_entries_for_config_entry(entity_registry, mock_config_entry_v2.entry_id)
+        } == {
+            f"{HMIP_DOMAIN}_loom_{self._SERIAL}_sysvar_12345",
+            f"{HMIP_DOMAIN}_loom_{self._SERIAL}_sysvar_67890",
+        }, "the second pass did not migrate, so it does not test the guard"
+        scheduled_reload.assert_called_once_with(mock_config_entry_v2.entry_id)
+
     async def test_two_sysvars_differing_only_in_punctuation(
         self, hass: HomeAssistant, mock_config_entry_v2: MockConfigEntry
     ) -> None:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -2,8 +2,7 @@
 
 from __future__ import annotations
 
-import ast
-import pathlib
+from collections.abc import Iterator
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -42,13 +41,13 @@ from tests import const
 class TestSweepSparesUnmigratedHubKeys:
     """A pre-id sysvar / program key is not an orphan while its data point is live.
 
-    The slug-to-id migration runs at the end of ``start_central()``, before any
-    entity exists. When it does not take — ``get_hub_data_points()`` raised, or
-    a data point yielded no old key — the historied entry keeps the slug, and
-    without this exemption the sweep 60 s later reads it as an orphan (no device
-    address, so ``_is_orphan_registry_entry`` falls through to ``True``) and
-    deletes it with its history, name and area. Keeping it costs one more start;
-    deleting it is permanent.
+    The slug-to-id migration runs just before this sweep, in the same callback.
+    When it does not take — ``get_hub_data_points()`` raised, or a data point
+    yielded no old key — the historied entry keeps the slug, and without this
+    exemption the sweep reads it as an orphan (no device address, so
+    ``_is_orphan_registry_entry`` falls through to ``True``) and deletes it with
+    its history, name and area. Keeping it costs one more start; deleting it is
+    permanent.
     """
 
     _SERIAL = "11a0001234"
@@ -105,66 +104,6 @@ class TestSweepSparesUnmigratedHubKeys:
         entity_registry = er.async_get(hass)
         assert entity_registry.async_get(alive.entity_id) is not None
         assert entity_registry.async_get(unmigrated.entity_id) is not None
-
-
-def _call_line(func: ast.AsyncFunctionDef, attribute: str) -> int:
-    """Return the line of the sole call to ``attribute`` in ``func``, bare or attribute-style."""
-    lines = [
-        node.lineno
-        for node in ast.walk(func)
-        if isinstance(node, ast.Call)
-        and (
-            (isinstance(node.func, ast.Attribute) and node.func.attr == attribute)
-            or (isinstance(node.func, ast.Name) and node.func.id == attribute)
-        )
-    ]
-    assert len(lines) == 1, f"expected exactly one call to {attribute}, found {len(lines)}"
-    return lines[0]
-
-
-class TestSetupOrdering:
-    """Every registry re-key must land before an entity holds the new key.
-
-    ``start_central()`` runs the slug-to-id hub migration at its end, where the
-    hub data is loaded (``init_hub()`` awaits the program and sysvar fetches
-    inside ``start_clients()``) and no platform has been forwarded. Forward the
-    platforms first and a freshly spawned twin already holds the new key, so the
-    migration has to remove that twin — which detaches the live entity and
-    leaves the historied entry bound to nothing until the next restart. That was
-    the shipped behaviour and the reason an update needed two restarts.
-
-    The constraint is an ordering between two awaits with no observable a unit
-    test can reach without standing up the whole setup path, so it is read off
-    the source of ``async_setup_entry`` itself.
-    """
-
-    @staticmethod
-    def _setup_entry() -> ast.AsyncFunctionDef:
-        source = pathlib.Path(custom_components.homematicip_local.__file__).read_text(encoding="utf-8")
-        return next(
-            node
-            for node in ast.parse(source).body
-            if isinstance(node, ast.AsyncFunctionDef) and node.name == "async_setup_entry"
-        )
-
-    def test_platforms_are_forwarded_after_the_central_starts(self) -> None:
-        """The re-keys inside start_central() run while no entity exists."""
-        function = self._setup_entry()
-        assert _call_line(function, "start_central") < _call_line(function, "async_forward_entry_setups")
-
-    def test_the_central_state_signal_follows_the_platforms(self) -> None:
-        """The backup button can only hear the signal once it is on the bus."""
-        function = self._setup_entry()
-        assert _call_line(function, "async_forward_entry_setups") < _call_line(
-            function, "async_signal_central_state_changed"
-        )
-
-    def test_the_serial_reanchor_also_precedes_the_platforms(self) -> None:
-        """The other re-key pass on this path needs the same empty registry."""
-        function = self._setup_entry()
-        assert _call_line(function, "_async_reanchor_hub_unique_ids_on_serial_change") < _call_line(
-            function, "async_forward_entry_setups"
-        )
 
 
 class TestSetupEntry:
@@ -1505,10 +1444,16 @@ class TestHubKeyMigrationAgainstTheRegistry:
     already taken — the "unique id already in use" that aborts a config entry.
     """
 
+    @pytest.fixture(autouse=True)
+    def scheduled_reload(self, hass: HomeAssistant) -> Iterator[MagicMock]:
+        """Capture the reload the migration schedules instead of performing it."""
+        with patch.object(hass.config_entries, "async_schedule_reload") as scheduled:
+            yield scheduled
+
     _SERIAL = "11a0001234"
 
     async def test_historied_entry_takes_the_id_key(
-        self, hass: HomeAssistant, mock_config_entry_v2: MockConfigEntry
+        self, hass: HomeAssistant, mock_config_entry_v2: MockConfigEntry, scheduled_reload: MagicMock
     ) -> None:
         """The pre-upgrade entry keeps its entity_id and gains the new key."""
         mock_config_entry_v2.add_to_hass(hass)
@@ -1532,8 +1477,14 @@ class TestHubKeyMigrationAgainstTheRegistry:
         migrated = entity_registry.async_get(old.entity_id)
         assert migrated is not None, "the historied entry was removed instead of migrated"
         assert migrated.unique_id == f"{HMIP_DOMAIN}_loom_{self._SERIAL}_sysvar_12345"
+        # The renamed entry has no live entity: the one that existed was bound
+        # to the twin this pass just removed. Without the reload it stays gone
+        # until the user restarts — the two restarts an update used to need.
+        scheduled_reload.assert_called_once_with(mock_config_entry_v2.entry_id)
 
-    async def test_second_run_changes_nothing(self, hass: HomeAssistant, mock_config_entry_v2: MockConfigEntry) -> None:
+    async def test_second_run_changes_nothing(
+        self, hass: HomeAssistant, mock_config_entry_v2: MockConfigEntry, scheduled_reload: MagicMock
+    ) -> None:
         """Idempotent: the pass runs on every start-up, not only the first."""
         mock_config_entry_v2.add_to_hass(hass)
         self._seed(
@@ -1562,6 +1513,9 @@ class TestHubKeyMigrationAgainstTheRegistry:
             for entry in er.async_entries_for_config_entry(entity_registry, mock_config_entry_v2.entry_id)
         }
         assert after_second == after_first
+        # And the reload does not repeat — a pass that migrates nothing
+        # schedules nothing, so this cannot become a loop.
+        scheduled_reload.assert_called_once_with(mock_config_entry_v2.entry_id)
 
     async def test_two_sysvars_differing_only_in_punctuation(
         self, hass: HomeAssistant, mock_config_entry_v2: MockConfigEntry


### PR DESCRIPTION
Fixes a regression I introduced in #1275, reported from a live install **on the aiohomematic backend**: alarm messages, inbox, service messages and the per-interface connectivity sensors stopped being provided.

## What broke

#1275 moved `async_forward_entry_setups` after `start_central()` so the slug→id hub key migration could run before any entity existed. I checked that the platforms enumerate what the central already holds — and they do, but only two things:

- device data points, via `query_facade.get_data_points(registered=False)`
- hub data points, via `hub_coordinator.get_hub_data_points(registered=False)` — which returns **programs and sysvars only** (`aiohomematic/central/coordinators/hub.py:380-384`)

The hub singletons are not in that tuple and no platform enumerates them. They reach Home Assistant solely through `DataPointsCreatedEvent` → `signal_new_data_point` — on aiohomematic from `_emit_hub_refreshed_event` (`aiohomematic/central/coordinators/event.py:524-537`), on loom from the adapter's single announcement, whose comment states the constraint outright (`openccu_loom_client/compat/aiohomematic/central/adapter.py:1527-1530`: *"no later event would re-announce them"*). With the platforms not yet forwarded, that dispatch had no listeners, and nothing re-announces.

Lost that way: the hub singletons (alarm/service messages, inbox, connectivity, metrics, install mode), the per-device update data points, the event groups and the alarm panels. Both backends.

The suite passed 955/955 through all of this: nothing covers singleton spawn. That gap is real and worth closing separately.

## The fix

Restore the original order, and solve the twin problem where it actually appears. When the migration renames anything, it schedules a config-entry reload:

```python
self._hass.config_entries.async_schedule_reload(self._entry_id)
```

The renamed entry holds the history but nothing live — the entity that existed was bound to the twin the migration just removed, and binding only happens at `async_add_entities`. The reload re-binds it within seconds instead of at the user's next restart, which is the two-restart symptom that started this.

It runs once per config entry per Home Assistant run, tracked in `hass.data` so the marker survives the reload it triggers. Idempotency alone would already give that — a second pass migrates nothing and asks for nothing — but an automatic reload loop is a bad enough failure to close by construction rather than by argument. A second migrating pass logs a warning and leaves the re-bind to the next restart: reaching it would mean the pass did not converge, and reloading again would not converge either.

## Kept from #1275

The orphan-sweep exemption. It matters more now, not less: the migration is back in the position where a failure (`get_hub_data_points()` raises, or a data point yields no old key) leaves slug-keyed entries for the sweep to find 60 s later.

## Tests

Three new assertions, each **verified to fail without the code it covers**:

- a migrating pass schedules the reload for the right entry
- a second, no-op pass does not schedule again
- a second *migrating* pass does not schedule again either — with an assertion that it really did migrate, so the test cannot pass by not exercising the guard

`TestSweepSparesUnmigratedHubKeys` from #1275 is unchanged and still green. `TestSetupOrdering` from #1275 is removed — it pinned the ordering this PR reverses.

Full suite: 953 passed, 8 skipped.