### PR TITLE
docs+test: correct the comparison numbers, cover the one silent channel

### DIFF
--- a/custom_components/homematicip_local/control_unit.py
+++ b/custom_components/homematicip_local/control_unit.py
@@ -645,11 +645,12 @@ class ControlUnit(BaseControlUnit):
             )
 
         # The pre-id keys the slug-to-id migration would rename onto one of the
-        # live data points above. It runs at the end of start_central(), so an
-        # entry still holding one here means it did not: it raised, or that data
-        # point yielded no old key. Deletion is permanent and the next start
-        # retries the migration, so these are kept rather than swept — the same
-        # reasoning as the central-id drift exemption below.
+        # live data points above. It runs in this same callback, immediately
+        # before this sweep, so an entry still holding one here means it did
+        # not take: it raised, or that data point yielded no old key. Deletion
+        # is permanent and the next start retries the migration, so these are
+        # kept rather than swept — the same reasoning as the central-id drift
+        # exemption below.
         migratable_unique_ids: set[str] = {
             f"{DOMAIN}_{old_unique_id}"
             for dp in hub_data_points

--- a/docs/architecture-comparison-aiohomematic-vs-loom.md
+++ b/docs/architecture-comparison-aiohomematic-vs-loom.md
@@ -76,9 +76,11 @@ stands as written.
 | **Extra surfaces** | HA only | MQTT (HA Discovery), Matter, Web Config-UI |
 
 **The central finding:** Loom does **not reduce** total complexity — it
-**relocates and re-implements** it. The thin client (~14k LOC) is only thin
-because a ~232k-LOC Go daemon now carries the device-profile, paramset, and
-classification logic that aiohomematic does in-process. In exchange Loom buys a
+**relocates and re-implements** it. The client (21,730 LOC hand-maintained,
+plus 5,587 generated wire types — see the note above; ~14k when this was
+written) is only thin relative to a ~232k-LOC Go daemon that now carries the
+device-profile, paramset, and classification logic aiohomematic does
+in-process. In exchange Loom buys a
 **cleaner wire model** (compact BIN-RPC south-bound, delta-only JSON over an
 outgoing WebSocket north-bound, no inbound callback server) at the cost of an
 **additional stateful, version-coupled daemon** as a new single point of failure
@@ -224,7 +226,7 @@ traffic): MQTT (`north.mqtt.enabled: false` by default), Matter
 (`north.matter.enabled: false`). Both are north-bound adapters on the **same
 in-process EventBus** — they do not open a second CCU link.
 
-### 3.2 The thin client (`openccu-loom-client`, ~14k LOC Python)
+### 3.2 The client (`openccu-loom-client`, 21,730 LOC hand-maintained + 5,587 generated)
 
 Consumes the daemon over **one persistent outgoing WebSocket** (events) + **REST**
 (commands, snapshot, refresh) against one port/auth family (Basic / Bearer /
@@ -378,11 +380,18 @@ Protocol. Quality is high and deliberate:
 - **One shared interface**, no `if loom` sauce threaded through entities. Only
   **~11 real branch sites** total (3 in `control_unit.py`, 4 in `__init__.py`,
   4 in `config_flow.py`).
-- **`backend_types.py`** resolves the one structural friction: aiohomematic's
-  Protocol metaclass blocks both subclassing and `ABCMeta.register`, so platform
-  dispatch uses `isinstance` tuples pairing each aiohomematic class with its Loom
-  twin, degrading to the aiohomematic class alone on a CCU-only install
-  (`backend_types.py:55-67`). Used by 7 platforms.
+- **`backend_types.py`** resolves the one structural friction. Not for the
+  reason first given here: subclassing an aiohomematic model class *works*
+  (measured, 15 of 15 dispatch classes). What rules the alternatives out is that
+  `ABCMeta.register` fails **silently** — `CustomDpCover.register(cls)` returns
+  without error and `isinstance` stays `False` — and that inheriting is worse
+  than useless, because a twin must skip `__init__` (aiohomematic's constructors
+  want a live `CentralUnit`) and then 93 of 153 members raise on access, 42 of
+  them public. So platform dispatch uses `isinstance` tuples pairing each
+  aiohomematic class with its Loom twin, degrading to the aiohomematic class
+  alone on a CCU-only install (`backend_types.py:5-21`, which carries the
+  measurement). Used by 7 platforms — with cover and siren since moved onto the
+  `@runtime_checkable` category protocols in `aiohomematic.interfaces.custom`.
 - **Polymorphism instead of branching** elsewhere: an `isawaitable` pattern for
   `get_paramset_description` (sync+cached on aiohomematic, async REST on Loom,
   `websocket_api.py:266-276`) and a `NotImplementedError` guard for event groups
@@ -474,8 +483,8 @@ shipping reality" with "the architecture on its merits" would be misleading.
 | Network footprint (quantity) | 6 | **8** | 9 when daemon on-CCU; ~7 when daemon separate (both hops on LAN) |
 | NAT / firewall friendliness | 4 | **9** | outgoing WS only vs. required inbound callback listener |
 | Startup performance / scalability | 7 | 6 | aiohomematic disk-cache + bulk fetch vs. client N×M fan-out (daemon warm-start is strong, 8) |
-| HA-process footprint | 5 | **9** | 74k in-process vs. ~14k thin adapter |
-| Total system complexity | **7** | 4 | one library vs. daemon (232k Go) + client + types + SQLite |
+| HA-process footprint | 5 | 7 | 74k in-process vs. 27k client, of which 10k is the compat shim (was scored 9 against the ~14k figure) |
+| Total system complexity | **7** | 4 | one library vs. daemon (232k Go) + client + SQLite (the separate types distribution was folded into the client in 2026-08) |
 | Integration abstraction cleanliness | — | **8** | clean `CentralUnit` façade, ~11 branch sites (aiohomematic *is* the interface) |
 | Maturity / production readiness (in HA) | **10** | 4 | default backend vs. disabled groundwork (daemon now parity-complete; HA backend still gated off) |
 | Robustness / reconnect | **9** | 8 | both strong; Loom carries daemon SPOF |

--- a/tests/contract/test_backend_types_pair_warning.py
+++ b/tests/contract/test_backend_types_pair_warning.py
@@ -1,0 +1,65 @@
+"""The one silent channel between this integration and openccu-loom-client.
+
+`_pair` builds the `isinstance` tuple each platform dispatches on: the
+aiohomematic class plus its loom twin. When `openccu-loom-client` is installed
+but no longer exposes a twin — renamed, removed, or a version mismatch — the
+tuple degrades to the aiohomematic class alone. Every loom entity of that type
+then falls out of its platform: a blind loses its tilt, a garage loses its
+class, a sound player loses its soundfiles.
+
+That degradation is deliberate, because a hard failure would take the whole
+integration down over one missing twin. What it must not be is quiet, and it
+used to be: no error, no log, no test. The warning closed the first half.
+This closes the second — the warning is the only signal that exists, so
+nothing may remove it without a test going red.
+
+The twin-drift test in `test_backend_surface_contract.py` covers the other
+case, where both packages are current and a name has moved. It cannot cover
+this one: it compares two installed packages, and the failure here is an
+installed package that is the wrong version.
+"""
+
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+
+import pytest
+
+from custom_components.homematicip_local.backend_types import _pair
+
+
+class _AioClass:
+    """Stand-in for an aiohomematic dispatch class."""
+
+
+class _LoomTwin:
+    """Stand-in for its openccu-loom-client twin."""
+
+
+def test_both_present_yields_the_pair(caplog: pytest.LogCaptureFixture) -> None:
+    """The normal case: platforms dispatch on both classes and nothing is logged."""
+    module = SimpleNamespace(CustomDpCover=_LoomTwin)
+    with caplog.at_level(logging.WARNING):
+        assert _pair(_AioClass, "CustomDpCover", module) == (_AioClass, _LoomTwin)
+    assert caplog.records == []
+
+
+def test_a_missing_twin_warns_and_names_it(caplog: pytest.LogCaptureFixture) -> None:
+    """The degradation is announced, and the message identifies which twin went."""
+    module = SimpleNamespace()  # imported, so the client is installed — but no twin
+    with caplog.at_level(logging.WARNING):
+        result = _pair(_AioClass, "CustomDpCover", module)
+
+    assert result == (_AioClass,), "the tuple must still degrade rather than fail the setup"
+    assert len(caplog.records) == 1, "the only signal this failure has is the warning"
+    message = caplog.records[0].getMessage()
+    assert "CustomDpCover" in message, "a warning that does not name the twin cannot be acted on"
+    assert "version mismatch" in message
+
+
+def test_no_client_installed_is_silent(caplog: pytest.LogCaptureFixture) -> None:
+    """A CCU-only install has no twins to miss, so it must not be warned at."""
+    with caplog.at_level(logging.WARNING):
+        assert _pair(_AioClass, "CustomDpCover", None) == (_AioClass,)
+    assert caplog.records == []


### PR DESCRIPTION
Three findings from the implementation review of the 2026-08-28 architecture memo.

## The comparison document argued from a superseded number

Its preamble was corrected in August, but three places downstream kept quoting **"~14k LOC thin adapter"**: §1's central finding (`:79`), the §3.2 heading (`:227`), and the §7 evaluation matrix (`:477`) — the last being the line a backend decision actually gets read from.

Measured today:

| | LOC |
|---|---|
| `openccu_loom_client/` total | 27,312 |
| of which generated (`wire/`) | 5,587 |
| hand-maintained | 21,730 |
| of which `compat/` | 10,048 (46 %) |

The HA-process footprint score drops from **9 to 7** and now states what it was scored against. The total-complexity row still listed the separate types distribution, folded into the client in August.

## It also still carried the metaclass claim this repository disproved

`backend_types.py:5-21` has said since #1267 that **subclassing works** — 15 of 15 dispatch classes, measured — and that the real reasons the alternatives fail are different: `ABCMeta.register` returns without error while `isinstance` stays `False`, and a twin that skips `__init__` (it must — aiohomematic's constructors want a live `CentralUnit`) raises on 93 of 153 members, 42 of them public.

The document asserted the original, disproved version in the present tense. Two places asserting different things is how a settled question gets reopened every six months. The bullet now carries the measurement and points at the source, and notes that cover and siren have since moved onto the `interfaces.custom` protocols.

## `_pair`'s warning had no test

`_pair` builds the `isinstance` tuple each platform dispatches on. When `openccu-loom-client` is installed but no longer exposes a twin, the tuple degrades to the aiohomematic class alone and every loom entity of that type falls out of its platform — a blind loses its tilt, a garage loses its class, a sound player loses its soundfiles.

The degradation is right: failing hard over one missing twin would take the whole integration down. What it must not be is quiet, and it was until #1267 added the warning — after which nothing stopped the warning being removed again. `grep -rn 'caplog' tests/contract/test_backend_surface_contract.py` returned 0.

Three cases pin it now: both present logs nothing and returns the pair; a missing twin returns `(aio_cls,)`, logs exactly one warning, and names the twin; a CCU-only install stays silent. The existing twin-drift test covers the other failure — two current packages, a moved name — and structurally cannot cover this one, because the failure here *is* the wrong version.

## Also

A comment left stale by #1276 (`control_unit.py:648`): the hub key migration runs in the scheduled cleanup callback again, not at the end of `start_central()`.

## Tests

958 passed, 8 skipped.