### PR TITLE
feat(diagnostics)+test: answer the two questions telemetry was blamed for

### DIFF
--- a/custom_components/homematicip_local/diagnostics.py
+++ b/custom_components/homematicip_local/diagnostics.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import asdict
+import re
 from typing import Any
 
 from aiohomematic.const import CONF_PASSWORD, CONF_USERNAME
@@ -13,6 +14,12 @@ from . import HomematicConfigEntry
 from .control_unit import ControlUnit
 
 REDACT_CONFIG = {CONF_USERNAME, CONF_PASSWORD}
+
+# Same shape the routing-key scoping in `__init__.py` recognises: ``CUX`` plus a
+# two-digit device type plus a five-digit running number, so ``CUX2801001``.
+# Matched against the device address here rather than a unique_id, so it is
+# anchored and not surrounded by key separators.
+_CUXD_ADDRESS = re.compile(r"^CUX\d{7}", re.IGNORECASE)
 
 
 async def async_get_config_entry_diagnostics(hass: HomeAssistant, entry: HomematicConfigEntry) -> dict[str, Any]:
@@ -49,5 +56,24 @@ async def async_get_config_entry_diagnostics(hass: HomeAssistant, entry: Homemat
         }
         for client in central.client_coordinator.clients
     }
+
+    # Two questions an architecture review could not answer from any repository:
+    # does anyone run a daemon fronting several CCUs, and do CUxD devices occur
+    # in production. Each decides whether a known divergence is a correctness
+    # problem or a footnote, and neither is measurable without telemetry — which
+    # this integration does not have and should not grow. A diagnostics dump
+    # answers both without reporting anything: the numbers reach a maintainer
+    # only when a user chooses to attach their own dump to a bug report.
+    #
+    # `daemon_central_count` exists on the openccu-loom adapter only, and only
+    # from the release that publishes it, so it is read defensively and omitted
+    # rather than guessed — the same treatment as `device_registry` above.
+    deployment: dict[str, Any] = {
+        "backend": control_unit.config.backend,
+        "cuxd_devices": sum(1 for device in central.device_coordinator.devices if _CUXD_ADDRESS.match(device.address)),
+    }
+    if (central_count := getattr(central, "daemon_central_count", None)) is not None:
+        deployment["daemon_centrals"] = central_count
+    diag["deployment"] = deployment
 
     return diag

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -25,6 +25,14 @@ class _SystemInformation:
     version: str
 
 
+def _device(*, address: str, model: str = "HmIP-BSM") -> MagicMock:
+    """Return a device mock with the two attributes diagnostics reads."""
+    device = MagicMock()
+    device.address = address
+    device.model = model
+    return device
+
+
 class TestAsyncGetConfigEntryDiagnostics:
     """Tests for async_get_config_entry_diagnostics function."""
 
@@ -93,6 +101,17 @@ class TestAsyncGetConfigEntryDiagnostics:
         mock_client_coordinator.clients = (mock_client,)
         control_unit.central.client_coordinator = mock_client_coordinator
 
+        # Two CUxD devices among three. The shape is what identifies the family
+        # (``CUX`` + two-digit type + five-digit running number), so the third
+        # address must not match on the prefix alone.
+        control_unit.central.device_coordinator.devices = (
+            _device(address="VCU0000001"),
+            _device(address="CUX2801001"),
+            _device(address="CUX9000123"),
+        )
+        control_unit.config.backend = "ccu"
+        del control_unit.central.daemon_central_count
+
         diag = await async_get_config_entry_diagnostics(hass, entry)
 
         # Config redaction: ensure sensitive fields are not equal to the original ones
@@ -137,6 +156,14 @@ class TestAsyncGetConfigEntryDiagnostics:
         assert throttle_data["burst_threshold"] == 5
         assert throttle_data["burst_window"] == 0.5
 
+        # The deployment shape: what an architecture review could not measure
+        # from the repositories, answerable from a dump the user attaches.
+        assert diag["deployment"]["backend"] == "ccu"
+        assert diag["deployment"]["cuxd_devices"] == 2
+        # A central without the loom adapter's counter omits the key rather
+        # than reporting a zero that would read as "one CCU".
+        assert "daemon_centrals" not in diag["deployment"]
+
     @pytest.mark.asyncio
     async def test_degrades_on_loom_shaped_central(self, hass, mock_loaded_config_entry) -> None:
         """It should build a payload when the central lacks the ccu-only surfaces.
@@ -154,11 +181,12 @@ class TestAsyncGetConfigEntryDiagnostics:
         del central.device_registry
         del central.metrics_aggregator
 
-        device_a = MagicMock()
-        device_a.model = "HmIP-SWDO"
-        device_b = MagicMock()
-        device_b.model = "HmIP-BSM"
-        central.device_coordinator.devices = (device_a, device_b)
+        central.device_coordinator.devices = (
+            _device(address="VCU0000002", model="HmIP-SWDO"),
+            _device(address="VCU0000003", model="HmIP-BSM"),
+        )
+        central.daemon_central_count = 2
+        control_unit.config.backend = "openccu-loom"
 
         central.system_information = _SystemInformation(serial="ABC123", version="1.2.3")
 
@@ -185,3 +213,11 @@ class TestAsyncGetConfigEntryDiagnostics:
         assert diag["system_health"] == {"overall_score": 100}
         assert diag["incident_store"] == {"incidents": []}
         assert diag["command_throttle"] == {}
+        # The loom adapter publishes the central count, so it is carried —
+        # this is the case that makes "is anyone on a multi-CCU daemon?"
+        # answerable from a dump the user attaches to a report.
+        assert diag["deployment"] == {
+            "backend": "openccu-loom",
+            "cuxd_devices": 0,
+            "daemon_centrals": 2,
+        }

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -15,6 +15,7 @@ import custom_components.homematicip_local
 from custom_components.homematicip_local import (
     _aiohomematic_restored_unique_id,
     _async_migrate_aiohomematic_hub_unique_ids,
+    _async_migrate_cuxd_unique_ids,
     _async_migrate_loom_unique_ids,
     _async_reanchor_hub_unique_ids_on_serial_change,
     _async_restore_aiohomematic_unique_ids,
@@ -812,6 +813,125 @@ async def test_cleanup_orphan_entries_removes_hub_anchored_entry_regardless_of_d
     ControlUnit._async_cleanup_orphaned_entity_registry_entries(fake_self)
 
     assert entity_registry.async_get(hub_orphan.entity_id) is None
+
+
+class TestCuxdMigrationAgainstTheRegistry:
+    """The registry walk of the CUxD scoping pass, not just its arithmetic.
+
+    `TestCuxdUniqueIdScoping` covers the key rebuild. This covers what happens
+    to a registry, which is what a user actually loses: whether the historied
+    entry keeps its entity_id, what becomes of a freshly keyed duplicate, and
+    that a rename is never attempted onto a key already taken — the "unique id
+    already in use" that aborts a config entry and fails setup.
+
+    Worth having because the pass is not hypothetical for anyone: it runs on
+    both backends, and on a direct-CCU install *every* CUxD entity is
+    affected. The maintainer runs CUxD devices, so this touches real
+    registries rather than a shape nobody has.
+    """
+
+    _CENTRAL = "11a0001234"
+    _DOMAIN_PREFIX = HMIP_DOMAIN
+
+    @staticmethod
+    def _seed(hass: HomeAssistant, entry: MockConfigEntry, *, unique_id: str, entity_suffix: str) -> er.RegistryEntry:
+        return er.async_get(hass).async_get_or_create(
+            domain="sensor",
+            platform=HMIP_DOMAIN,
+            unique_id=unique_id,
+            suggested_object_id=entity_suffix,
+            config_entry=entry,
+        )
+
+    async def test_a_non_cuxd_entry_is_left_alone(
+        self, hass: HomeAssistant, mock_config_entry_v2: MockConfigEntry
+    ) -> None:
+        """An install with no CUxD devices sees nothing happen — the docstring's promise."""
+        mock_config_entry_v2.add_to_hass(hass)
+        untouched = self._seed(
+            hass,
+            mock_config_entry_v2,
+            unique_id=f"{self._DOMAIN_PREFIX}_vcu0000001_1_state",
+            entity_suffix="regular_switch",
+        )
+
+        await _async_migrate_cuxd_unique_ids(hass, mock_config_entry_v2, namespace="", central_id=self._CENTRAL)
+
+        entity_registry = er.async_get(hass)
+        assert entity_registry.async_get(untouched.entity_id).unique_id == untouched.unique_id
+
+    async def test_a_second_run_changes_nothing(
+        self, hass: HomeAssistant, mock_config_entry_v2: MockConfigEntry
+    ) -> None:
+        """The pass runs on every start-up, so it has to be idempotent."""
+        mock_config_entry_v2.add_to_hass(hass)
+        self._seed(
+            hass,
+            mock_config_entry_v2,
+            unique_id=f"{self._DOMAIN_PREFIX}_cux2801001_1_state",
+            entity_suffix="cuxd_switch",
+        )
+        entity_registry = er.async_get(hass)
+
+        await _async_migrate_cuxd_unique_ids(hass, mock_config_entry_v2, namespace="", central_id=self._CENTRAL)
+        after_first = {
+            (e.entity_id, e.unique_id)
+            for e in er.async_entries_for_config_entry(entity_registry, mock_config_entry_v2.entry_id)
+        }
+
+        await _async_migrate_cuxd_unique_ids(hass, mock_config_entry_v2, namespace="", central_id=self._CENTRAL)
+        after_second = {
+            (e.entity_id, e.unique_id)
+            for e in er.async_entries_for_config_entry(entity_registry, mock_config_entry_v2.entry_id)
+        }
+        assert after_second == after_first
+
+    async def test_a_taken_target_key_is_skipped_not_raised(
+        self, hass: HomeAssistant, mock_config_entry_v2: MockConfigEntry
+    ) -> None:
+        """The collision must not abort setup.
+
+        `async_migrate_entries` propagates a duplicate-unique_id error, which
+        would fail the whole config entry — every entity gone, not just this
+        one. The duplicate is the entry without history, so skipping is right;
+        what matters is that the historied entry survives either way.
+        """
+        mock_config_entry_v2.add_to_hass(hass)
+        old_key = f"{self._DOMAIN_PREFIX}_cux2801001_1_state"
+        new_key = _cuxd_scoped_unique_id(old_key, namespace="", central_id=self._CENTRAL)
+        assert new_key is not None
+
+        historied = self._seed(hass, mock_config_entry_v2, unique_id=old_key, entity_suffix="cuxd_historied")
+        twin = self._seed(hass, mock_config_entry_v2, unique_id=new_key, entity_suffix="cuxd_twin")
+
+        await _async_migrate_cuxd_unique_ids(hass, mock_config_entry_v2, namespace="", central_id=self._CENTRAL)
+
+        entity_registry = er.async_get(hass)
+        assert entity_registry.async_get(historied.entity_id) is not None, "setup-aborting collision"
+        assert entity_registry.async_get(historied.entity_id).unique_id == old_key
+        assert entity_registry.async_get(twin.entity_id).unique_id == new_key
+
+    async def test_the_historied_entry_gains_the_central_slot(
+        self, hass: HomeAssistant, mock_config_entry_v2: MockConfigEntry
+    ) -> None:
+        """A CUxD entry is re-keyed in place, keeping its entity_id and history."""
+        mock_config_entry_v2.add_to_hass(hass)
+        seeded = self._seed(
+            hass,
+            mock_config_entry_v2,
+            unique_id=f"{self._DOMAIN_PREFIX}_cux2801001_1_state",
+            entity_suffix="cuxd_switch",
+        )
+
+        await _async_migrate_cuxd_unique_ids(hass, mock_config_entry_v2, namespace="", central_id=self._CENTRAL)
+
+        entity_registry = er.async_get(hass)
+        migrated = entity_registry.async_get(seeded.entity_id)
+        assert migrated is not None, "the entry was removed instead of migrated"
+        assert migrated.unique_id == _cuxd_scoped_unique_id(
+            f"{self._DOMAIN_PREFIX}_cux2801001_1_state", namespace="", central_id=self._CENTRAL
+        )
+        assert self._CENTRAL in migrated.unique_id
 
 
 class TestCuxdUniqueIdScoping:


### PR DESCRIPTION
An architecture review left two questions open as *"not measurable without telemetry"*:

- does anyone run a daemon fronting several CCUs?
- do CUxD devices occur in production?

Each decides whether a known divergence is a correctness problem or a footnote. Neither needed telemetry — one needed asking the maintainer, who answered **yes to both**. This makes them keep answering themselves.

## A diagnostics dump, not telemetry

`async_get_config_entry_diagnostics` gains a `deployment` block:

```json
"deployment": { "backend": "openccu-loom", "cuxd_devices": 2, "daemon_centrals": 2 }
```

Nothing is reported anywhere. These numbers reach a maintainer only when a user chooses to attach their own dump to a bug report — the mechanism that already exists for exactly this.

`daemon_centrals` comes from the openccu-loom adapter, which learns it from the CCU list it already fetches while resolving its own central (`openccu-loom-client` PR #150). It is read with `getattr` and **omitted** when absent, rather than defaulting to a zero that would read as "one CCU" — the same defensive treatment `device_registry` and `metrics_aggregator` already get here.

The CUxD address shape is the one `__init__.py:420-425` documents — `CUX` + two-digit device type + five-digit running number — anchored, because it matches an address rather than sitting inside a routing key.

## The CUxD registry pass gets the test it never had

`_async_migrate_cuxd_unique_ids` had coverage of its key *arithmetic* (`TestCuxdUniqueIdScoping`) and none of its registry walk. That is the same gap #1273 closed for the hub keys — and it matters more here: the pass runs on every start-up, on both backends, and on a direct-CCU install it touches **every** CUxD entity.

Four cases:

| | |
|---|---|
| historied entry | re-keyed in place, keeps its `entity_id` |
| non-CUxD entry | untouched — the docstring's "an installation with no CUxD devices sees nothing happen" |
| target key already taken | skipped, not raised. `async_migrate_entries` propagates a duplicate-`unique_id` error, which fails the whole config entry — every entity gone, not just this one |
| second run | changes nothing |

**Verified to bite:** forcing the migrator to return `None` reddens the first case.

## Tests

962 passed, 8 skipped.