### PR TITLE
chore(deps): openccu-loom-client 2026.8.37

### DIFF
--- a/custom_components/homematicip_local/manifest.json
+++ b/custom_components/homematicip_local/manifest.json
@@ -12,7 +12,7 @@
   "loggers": ["aiohomematic", "aiohomematic_config", "openccu_loom_client"],
   "requirements": [
     "openccu-data==2026.7.2",
-    "openccu-loom-client==2026.8.36",
+    "openccu-loom-client==2026.8.37",
     "aiohomematic-config==2026.8.1",
     "aiohomematic==2026.8.8"
   ],

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -6,7 +6,7 @@ aiohomematic==2026.8.8
 aiohomematic_config==2026.8.1
 isal==1.8.0
 openccu-data>=2026.7.2
-openccu-loom-client==2026.8.36
+openccu-loom-client==2026.8.37
 mypy<=2.1.0
 prek==0.5.0
 pur==7.4.0


### PR DESCRIPTION
Tracks the [2026.8.37](https://github.com/SukramJ/openccu-loom-client/releases/tag/2026.8.37) release, in `manifest.json` and `requirements_test.txt`.

## Why it matters here

It makes the `daemon_centrals` field added in #1279 actually appear. That field is read with `getattr` and omitted when absent, so the pin lag was **inert rather than broken** — the key was simply missing, which is exactly the behaviour this release adds it for.

## What else is in it

- **The bootstrap snapshot is scoped to one CCU** via `?central=`. A Home Assistant entry on a multi-CCU daemon no longer pulls, parses and discards the other CCU's whole device tree.
- **The client's drift guard follows this integration's move** onto the `aiohomematic.interfaces.custom` protocols — which nothing on either side had covered — and pins where each loom twin lands in the *ordered* cover dispatch rather than mere protocol membership. That is the structural form of the bug that once put every garage door in the cover branch.
- **Four user-facing messages** stop telling users to install `openccu-loom-types`, which no longer exists.

## Checks

Installed 2026.8.37 into the venv and ran against it: `LoomCentralAdapter.daemon_central_count` resolves, suite 962 passed, 8 skipped.