### PR TITLE
chore: bump openccu-loom-client to 2026.8.38

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,15 @@
 
 ### Integration
 
+- **Bump openccu-loom-client to 2026.8.38.** The client stopped classifying
+  CCU keypress / impulse / device-error parameters for itself and now reads
+  the event groups the daemon declares per channel (`ChannelSummary.
+  event_groups`, daemon 0.70.0). Entity identities are unchanged — the
+  client's computation and the daemon's had agreed byte for byte, which is
+  why the duplication went unnoticed for as long as it did. What changes is
+  that a device-trigger flavour the daemon adds no longer needs a matching
+  release here before it appears.
+
 - **Fix: switching backends no longer leaves every device behind and builds a second one beside it.** Both backends compose the HA device identifier as `<address>@<central>-<interface>`, but they disagree on the leading component: aiohomematic uses the Home Assistant instance name, the openccu-loom daemon its own CCU name (`OttoDev-HmIP-RF` against `Otto-HmIP-RF`, measured against daemon 0.68.1). Every device therefore re-keyed on a backend switch. The entities moved with it — their unique_ids are migrated — but the `device_id` did not, and that is what an area, a custom device name and every device-based automation hang on. The old entry stayed behind holding whatever had not migrated with it.
 
   The identifier is now composed by the integration itself, from the instance name and the interface *type* both backends report separately. On the direct-CCU backend that is byte-identical to what aiohomematic produced, so nothing moves there — the migration is a no-op for every installation that never touched the loom backend. A registry keyed the daemon's way is rewritten before the platforms come up, where the target key is still free and the rename is plain. Where a switch already happened and both entries exist, the older one wins: the newer entry's entities and sub-devices move over to it and it is removed, so the `device_id` the automations use is the one that survives.

--- a/custom_components/homematicip_local/manifest.json
+++ b/custom_components/homematicip_local/manifest.json
@@ -12,7 +12,7 @@
   "loggers": ["aiohomematic", "aiohomematic_config", "openccu_loom_client"],
   "requirements": [
     "openccu-data==2026.7.2",
-    "openccu-loom-client==2026.8.37",
+    "openccu-loom-client==2026.8.38",
     "aiohomematic-config==2026.8.1",
     "aiohomematic==2026.8.8"
   ],

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -6,7 +6,7 @@ aiohomematic==2026.8.8
 aiohomematic_config==2026.8.1
 isal==1.8.0
 openccu-data>=2026.7.2
-openccu-loom-client==2026.8.37
+openccu-loom-client==2026.8.38
 mypy<=2.1.0
 prek==0.5.0
 pur==7.4.0


### PR DESCRIPTION
**Blocked until openccu-loom-client 2026.8.38 is on PyPI** (currently
2026.8.37). CI here will fail to install until then — that is expected, not a
defect in the change. Upstream: SukramJ/openccu-loom-client#153.

## What the client change is

It stopped classifying CCU keypress / impulse / device-error parameter names
for itself and now reads the event groups the daemon declares per channel
(`ChannelSummary.event_groups`, daemon 0.70.0). That removed the fourth copy
of the same parameter set across this family of repositories — the kind of
copy that caps its holder at whatever its author wrote down, which is how the
daemon's MQTT plane came to publish keypresses alone while the model had
known three event kinds all along.

Entity identities do not move. The client's computation and the daemon's had
agreed byte for byte, which is exactly why the duplication went unnoticed.

Both pin sites move together: `manifest.json` is what Home Assistant
installs, `requirements_test.txt` is what CI tests, and `TestBackendPinsAgree`
fails on a mismatch.

## Verification, and its limit

- The pin guard passes.
- The full suite passes against the new client (978 passed, 8 skipped), run
  with `PYTHONPATH` pointed at the local checkout since the version is not
  published yet.

**That green run does not verify this change.** I falsified the client's
event-group `unique_id` and re-ran: all 978 still passed. Nothing in this
repository exercises the client's group builder — `test_event.py` names the
chain only in a comment. So the compatibility claim rests on the key's shape
being unchanged, which is a code reading of `support.py`'s
`_EVENT_GROUP_PREFIX` parsing against the client's output format, not a
measurement this suite can make. The client's own tests cover the identity;
this one cannot.