### PR TITLE
chore(deps): bump openccu-loom-client to 2026.9.2

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -42,11 +42,15 @@ The manifest still pinned `2026.8.7` while CI already ran `2026.8.8` — across 
 `tests/test_dependency_pins.py` now pins the two files together, the way the sister client repository does. Bite proof: restoring `2026.8.7` in the manifest fails it by name.
 
 
-#### Bump openccu-loom-client to `2026.9.1`
+#### Bump openccu-loom-client to `2026.9.2`
 
 openccu-loom backend (Beta) only — on the direct-CCU backend the client is not loaded, so this bump has no runtime effect there.
 
-- **It raises the minimum daemon**: the client is generated against daemon API `10.1.0`, up from `7.13.0` in 2.10.0, and checks it at connect time, so an older daemon is rejected outright. Installations that cannot update the daemon should stay on 2.10.0.
+Two client releases land in this integration release; what follows is the net effect against 2.10.0, because the intermediate one never shipped from here.
+
+- **A daemon version mismatch no longer refuses the connection.** The client used to demand the same API major and at least the same minor as the version it was generated against, and 2026.9.1 would have rejected an older daemon outright. It reports the difference now and connects; the only condition that still refuses is a daemon missing a capability this integration declares it needs. This matters in both directions, and the second one bit on ordinary releases: HACS updates this integration before you update the daemon, which used to make the daemon *older by a minor* and fail setup for a contract that was fully present. The advice to stay on 2.10.0 when the daemon cannot be updated no longer applies.
+- **A daemon that adds a value no longer breaks decoding.** Generated enums accept a value this build has not seen and carry it through as the raw string, instead of rejecting the whole response. Three daemon response shapes also stopped declaring themselves closed to unknown fields, so a field added later no longer does the same.
+- **When the two genuinely cannot work together**, the config flow now says so with its own message rather than reporting a connection failure — see the integration entry above.
 - **CUxD entities re-key once**; the migration that carries them is the integration entry above.
 - `openccu-loom-types` is no longer a separate dependency — it is folded into the client — so this bump removes a package from the install rather than pinning one.
 

--- a/custom_components/homematicip_local/manifest.json
+++ b/custom_components/homematicip_local/manifest.json
@@ -12,7 +12,7 @@
   "loggers": ["aiohomematic", "aiohomematic_config", "openccu_loom_client"],
   "requirements": [
     "openccu-data==2026.7.2",
-    "openccu-loom-client==2026.9.1",
+    "openccu-loom-client==2026.9.2",
     "aiohomematic-config==2026.8.1",
     "aiohomematic==2026.8.8"
   ],

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -6,7 +6,7 @@ aiohomematic==2026.8.8
 aiohomematic_config==2026.8.1
 isal==1.8.0
 openccu-data>=2026.7.2
-openccu-loom-client==2026.9.1
+openccu-loom-client==2026.9.2
 mypy<=2.1.0
 prek==0.5.1
 pur==7.4.0


### PR DESCRIPTION
The client release that stops a daemon update from breaking this integration. openccu-loom shipped its half in 0.72.0; this is the half that reaches users, because the daemon side cannot help a client that refuses to connect.

## What the bump changes

An installed client used to refuse whenever the daemon's API version differed by a major, or fell short by a minor. **The second direction is the one that bit on ordinary releases:** HACS updates this integration before the operator updates the daemon, which makes the daemon *older by a minor* — and setup failed for a contract that was fully present.

It reports the difference now and connects. The only condition that still refuses is a daemon missing a capability this integration declares it needs. On top of that, generated enums accept a value this build has not seen and carry it through as the raw string instead of rejecting the whole response, and three daemon response shapes stopped declaring themselves closed to unknown fields.

openccu-loom backend (Beta) only — on the direct-CCU backend the client is not loaded.

## Both pin sites move together

`custom_components/homematicip_local/manifest.json:15` and `requirements_test.txt:9`. Home Assistant installs the first, CI tests the second, so a half-done bump ships untested code. `tests/test_dependency_pins.py` holds them to each other.

**Bite proof:** reverting `requirements_test.txt` alone fails it by name —

> `openccu-loom-client pin drifted: manifest.json says 2026.9.2, requirements_test.txt says 2026.9.1. Home Assistant installs the manifest; CI tests the other — so a mismatch ships untested code.`

## The changelog entry is folded, not appended

The existing `2026.9.1` entry told operators that an older daemon is *"rejected outright"* and that installations unable to update the daemon *"should stay on 2.10.0"*. Both statements are precisely what this bump undoes.

2.10.1 is unreleased, so the two entries would have shipped together and contradicted each other inside the same section. The replacement gives the net effect against 2.10.0 — the version operators are actually coming from — and withdraws the advice explicitly rather than leaving it to be noticed.

## Verification

Full suite run **against the installed 2026.9.2**, not against whatever the venv happened to carry: **981 passed, 8 skipped**. The translation and flow-translation guards pass; `prettier` clean, which is the one that fails on a markdown emphasis character.