### PR TITLE
chore(release): 2.11.0, and bring the changelog up to what ships

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
         types_or: [python]
         files: ^(custom_components/homematicip_local|tests)/.+\.py$
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.16.5
+    rev: v0.16.6
     hooks:
       - id: ruff
         args:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ This document provides comprehensive guidance for AI assistants working with the
 
 **Project Name:** Homematic(IP) Local for OpenCCU
 **Type:** Home Assistant Custom Integration
-**Version:** 2.10.1
+**Version:** 2.11.0
 **Primary Language:** Python 3.14+
 **Domain:** `homematicip_local`
 
@@ -1146,7 +1146,7 @@ make hass
 
 ### Version Information
 
-- **Current Version:** 2.10.1
+- **Current Version:** 2.11.0
 - **Minimum HA Version:** 2026.8.0+
 - **Python Target:** 3.14+ (CI tests on 3.14)
 - **aiohomematic Version:** 2026.8.8
@@ -1174,4 +1174,4 @@ make hass
 ---
 
 **Last Updated**: 2026-09-03
-**Version**: 2.10.1
+**Version**: 2.11.0

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,4 @@
-# Version [2.10.1](https://github.com/SukramJ/homematicip_local/compare/2.10.0...2.10.1) (unreleased)
+# Version [2.11.0](https://github.com/SukramJ/homematicip_local/compare/2.10.0...2.11.0) (unreleased)
 
 ## What's Changed
 
@@ -8,7 +8,7 @@
 
   What that is worth depends entirely on the CCU. On one reporter's installation the integration delivered every keypress in about 6 ms and the seven measurable blueprint runs completed in 16–68 ms, while the same installation's RPC latency averaged 9.8 ms across 9571 calls with a maximum of 6.1 s — so the round trip is usually free and occasionally very expensive. A keypress arriving as a bundle (`PRESS_SHORT` + `PRESS_LONG` + `PRESS_LONG_RELEASE`) used to cost one lookup each.
 
-  Everything reading the answer moved into the same branch as the lookup, because variables set in a nested sequence do not escape it. That the `stop` for the skip option still ends the whole run from in there is asserted rather than assumed, as is the notification path. Reported as aiohomematic#3382, where the delay was attributed to Home Assistant 2026.9 — the lookup has been in these blueprints unchanged since 2026-04-14 and predates both that release and 2.10.1
+  Everything reading the answer moved into the same branch as the lookup, because variables set in a nested sequence do not escape it. That the `stop` for the skip option still ends the whole run from in there is asserted rather than assumed, as is the notification path. Reported as aiohomematic#3382, where the delay was attributed to Home Assistant 2026.9 — the lookup has been in these blueprints unchanged since 2026-04-14 and predates both that release and this one
 
 - **Fix: button presses reach automations again on Home Assistant 2026.9.** Every `homematic.keypress` and `homematic.impulse` event stopped being fired, so keypress blueprints, device triggers and any automation listening for a button lost their trigger — silently, with no trace to look at, while the event entity kept updating and the log showed only a DEBUG line per press: `The EVENT could not be validated. ['channel_no'], required key not provided`.
 
@@ -50,23 +50,27 @@
 
 ### Dependencies
 
-#### Bump aiohomematic to `2026.8.8`
+#### Bump aiohomematic to `2026.9.1`
+
+- **A `HmIP-HEATING` group no longer stays frozen at its restored state after a CCU restart** ([aiohomematic#3376](https://github.com/SukramJ/aiohomematic/issues/3376)). The climate entity gated its validity on `SET_POINT_MODE`, which the CCU sends only when the operating mode actually changes — while `ACTUAL_TEMPERATURE` and `SET_POINT_TEMPERATURE` keep arriving. A heating group whose mode had not been touched since the restart therefore kept showing frozen `current_temperature` and `target_temperature`, while its sibling `sensor.*` entities updated from the very same events. Groups on `VirtualDevices` have no second source to fall back on: the ReGa bulk fetch skips the mode data point and there is no per-parameter `getValue` for a virtual group. Validity now follows temperature and setpoint, and `mode` uses its existing `AUTO` fallback until `SET_POINT_MODE` arrives. A group missing `ACTUAL_TEMPERATURE` from the bulk result too still waits for its first event
+- **A system variable whose declared type does not match its value is kept as text instead of being dropped** ([aiohomematic#3377](https://github.com/SukramJ/aiohomematic/issues/3377)). `SysVar.getAll` reports a type per variable and it was trusted: a value list holding a single text entry returns that entry rather than its index, `int()` raised, the record was discarded, and no entity ever appeared — with an `ERROR` on every 60 s scan (4075 of them in the submitted log, for one variable). Disabling the entity did not help, because that is resolved before the value is parsed. The variable now falls back to `STRING` and keeps its raw value; it also drops `extended_sysvar`, so a type that could not be verified never yields a writable data point. The log is a `WARNING` now, once per variable per client, naming the declared type
 
 The manifest still pinned `2026.8.7` while CI already ran `2026.8.8` — across the very release that adopts 2026.8.8's re-keying of system variables and programs. The registry migration added for it was therefore tested against a backend that had re-keyed and would have shipped against one that had not.
 
 `tests/test_dependency_pins.py` now pins the two files together, the way the sister client repository does. Bite proof: restoring `2026.8.7` in the manifest fails it by name.
 
 
-#### Bump openccu-loom-client to `2026.9.2`
+#### Bump openccu-loom-client to `2026.9.3`
 
 openccu-loom backend (Beta) only — on the direct-CCU backend the client is not loaded, so this bump has no runtime effect there.
 
-Two client releases land in this integration release; what follows is the net effect against 2.10.0, because the intermediate one never shipped from here.
+Three client releases land in this integration release; what follows is the net effect against 2.10.0, because the intermediate ones never shipped from here.
 
 - **A daemon version mismatch no longer refuses the connection.** The client used to demand the same API major and at least the same minor as the version it was generated against, and 2026.9.1 would have rejected an older daemon outright. It reports the difference now and connects; the only condition that still refuses is a daemon missing a capability this integration declares it needs. This matters in both directions, and the second one bit on ordinary releases: HACS updates this integration before you update the daemon, which used to make the daemon *older by a minor* and fail setup for a contract that was fully present. The advice to stay on 2.10.0 when the daemon cannot be updated no longer applies.
 - **A daemon that adds a value no longer breaks decoding.** Generated enums accept a value this build has not seen and carry it through as the raw string, instead of rejecting the whole response. Three daemon response shapes also stopped declaring themselves closed to unknown fields, so a field added later no longer does the same.
 - **When the two genuinely cannot work together**, the config flow now says so with its own message rather than reporting a connection failure — see the integration entry above.
 - **CUxD entities re-key once**; the migration that carries them is the integration entry above.
+- **A week profile reported its active profile one index too low.** Regenerated wire bindings (daemon v0.73.0) carry the fix.
 - `openccu-loom-types` is no longer a separate dependency — it is folded into the client — so this bump removes a package from the install rather than pinning one.
 
 #### Bump aiohomematic to [2026.8.6](https://github.com/SukramJ/aiohomematic/compare/2026.8.5...2026.8.6)
@@ -79,7 +83,13 @@ Two client releases land in this integration release; what follows is the net ef
 
 #### Development dependencies
 
-`prek` `0.5.1`, `pytest-homeassistant-custom-component-framework` `1.0.50`.
+Against 2.10.0: `mypy` `<=2.1.0` → `<=2.3.1`, `prek` `0.5.0` → `0.5.2`, `pylint` `4.0.7` → `4.0.8`,
+`pytest-homeassistant-custom-component-framework` `1.0.47` → `1.0.52`, `ruff` `0.16.4` → `0.16.6`, and
+`aiohomematic-test-support` `2026.8.5` → `2026.9.1` following the runtime pin. Tooling only, no packaged
+behaviour changes.
+
+The `mypy` bump is the first one Dependabot raised here: this release put the Python requirements under it,
+having covered only GitHub Actions before.
 
 
 # Version [2.10.0](https://github.com/SukramJ/homematicip_local/compare/2.9.1...2.10.0) (2026-08-27)

--- a/custom_components/homematicip_local/manifest.json
+++ b/custom_components/homematicip_local/manifest.json
@@ -12,9 +12,9 @@
   "loggers": ["aiohomematic", "aiohomematic_config", "openccu_loom_client"],
   "requirements": [
     "openccu-data==2026.7.2",
-    "openccu-loom-client==2026.9.2",
+    "openccu-loom-client==2026.9.3",
     "aiohomematic-config==2026.8.1",
-    "aiohomematic==2026.8.8"
+    "aiohomematic==2026.9.1"
   ],
   "ssdp": [
     {
@@ -22,6 +22,6 @@
       "manufacturerURL": "https://openccu.de"
     }
   ],
-  "version": "2.10.1",
+  "version": "2.11.0",
   "zeroconf": ["_openccu-loom._tcp.local."]
 }

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,15 +1,15 @@
 -r requirements_test_pre_commit.txt
 
 async_upnp_client==0.48.1
-aiohomematic-test-support==2026.8.8
-aiohomematic==2026.8.8
+aiohomematic-test-support==2026.9.1
+aiohomematic==2026.9.1
 aiohomematic_config==2026.8.1
 isal==1.8.0
 openccu-data>=2026.7.2
-openccu-loom-client==2026.9.2
+openccu-loom-client==2026.9.3
 mypy<=2.3.1
 prek==0.5.2
 pur==7.4.0
 pylint==4.0.8
 pylint_strict_informational==0.1
-pytest-homeassistant-custom-component-framework==1.0.51
+pytest-homeassistant-custom-component-framework==1.0.52

--- a/requirements_test_pre_commit.txt
+++ b/requirements_test_pre_commit.txt
@@ -1,5 +1,5 @@
 bandit==1.9.4
 codespell==2.4.3
 python-typing-update==v0.8.1
-ruff==0.16.5
+ruff==0.16.6
 yamllint==1.38.0


### PR DESCRIPTION
## Dependencies

Bumped in the same change, so the changelog and the pins cannot disagree.

**aiohomematic `2026.8.8` → `2026.9.1`** — two user-facing fixes, both written up in the changelog:

- An `HmIP-HEATING` group stayed frozen at its restored state after a CCU restart whenever the operating mode was not touched ([aiohomematic#3376](https://github.com/SukramJ/aiohomematic/issues/3376)). Validity was gated on `SET_POINT_MODE`, which the CCU sends only on an actual mode change, while the sibling `sensor.*` entities kept updating from the same events.
- A system variable whose declared type did not match its value was dropped instead of kept as text ([aiohomematic#3377](https://github.com/SukramJ/aiohomematic/issues/3377)) — no entity ever appeared, and an `ERROR` was logged on every 60 s scan (4075 of them in the submitted log, for one variable).

**openccu-loom-client `2026.9.2` → `2026.9.3`** — regenerated wire bindings (daemon v0.73.0) and a week profile reporting its active profile one index too low. Held to one line: loom details stay out of scope while the backend is Beta.

**Tooling** — `ruff` `0.16.6` on both sides of the pin pair, test framework `1.0.52`, `aiohomematic-test-support` following the runtime pin.

## Changelog

The development-dependency section named two packages at versions that were already stale (`prek 0.5.1`, framework `1.0.50`) and omitted four more. It now states the actual delta against 2.10.0: `mypy` `<=2.1.0` → `<=2.3.1`, `prek` `0.5.0` → `0.5.2`, `pylint` `4.0.7` → `4.0.8`, framework `1.0.47` → `1.0.52`, `ruff` `0.16.4` → `0.16.6`, `aiohomematic-test-support` `2026.8.5` → `2026.9.1`.

I checked all 32 commits since `2.10.0` against the changelog. Everything else was already covered. **Not added, deliberately:** #1276, which fixed a regression #1275 introduced inside this same unreleased cycle — users only ever see the end state, which the existing entry already describes. Likewise the pure docs and CodeQL-bump commits.

## Checks

Run against the bumped packages (`aiohomematic 2026.9.1`, `openccu-loom-client 2026.9.3`), not the previously installed ones:

- `make test-ci` — 992 passed, 8 skipped
- `make prek` — all hooks green
- `aiohomematic` verified as the last entry in `manifest.json` requirements
